### PR TITLE
Unified LibreChat Init Service 

### DIFF
--- a/docker-compose.librechat.yml
+++ b/docker-compose.librechat.yml
@@ -1,487 +1,28 @@
 services:
-  config-init:
-    image: alpine:latest
-    container_name: librechat-config-init
+  librechat-init:
+    build:
+      context: ./packages/librechat-init
+      dockerfile: Dockerfile
+    image: librechat-init:latest
+    container_name: librechat-init
     restart: "no"
+    user: root
+    environment:
+      MONGO_URI: ${LIBRECHAT_MONGO_URI}
+      LIBRECHAT_DEFAULT_ADMINS: ${LIBRECHAT_DEFAULT_ADMINS:-}
+      UID: ${UID:-1000}
+      GID: ${GID:-1000}
     volumes:
       - librechat-config:/app/config
-    command:
-      - sh
-      - -c
-      - |
-        echo "Generating LibreChat configuration..."
-        
-        cat > /app/config/librechat.yaml << 'CONFIG_EOF'
-        version: 1.3.1
-        cache: true
-        
-        interface:
-          customWelcome: 'Hi {{user.name}}! Willkommen im KI Chat-Interface von Correctiv mit LibreChat'
-          fileSearch: true
-          privacyPolicy:
-            externalUrl: 'https://correctiv.org/kontakt/datenschutz/'
-            openNewTab: true
-          termsOfService:
-            externalUrl: 'https://correctiv.org'
-            openNewTab: true
-            modalAcceptance: true
-            modalTitle: 'Kleingedrucktes'
-            modalContent: |
-              # Nutzungsbedingungen
-        
-              **Wichtiger Hinweis zu KI-generierten Antworten**
-              Alle Antworten dieses KI-Systems sollten stets von Menschen überprüft werden. KI-generierte Inhalte können Fehler enthalten und sollten nicht als alleinige Quelle für wichtige Entscheidungen verwendet werden.
-        
-              **Datenverarbeitung und Hosting**
-              Wir bemühen uns, so viele Komponenten wie möglich selbst zu hosten. Aktuell nutzen wir noch externe Dienste wie OpenRouter, wodurch Daten derzeit an Server in den USA übertragen werden. Unser Ziel ist es, vollständig auf selbst gehostete oder europäische Dienste umzustellen.
-          endpointsMenu: true
-          modelSelect: true
-          parameters: true
-          sidePanel: true
-          presets: true
-          prompts: true
-          bookmarks: true
-          multiConvo: true
-          agents: true
-          peoplePicker:
-            users: true
-            groups: true
-            roles: true
-          marketplace:
-            use: true
-          fileCitations: true
-          search: true
-        
-        memory:
-          disabled: false
-          personalize: true
-          tokenLimit: 2000
-          messageWindowSize: 5
-          # Memory categories for journalism and fact-checking workflow
-          # Restricts memory storage to these structured categories for better consistency
-          validKeys:
-            # User preferences and communication style
-            - "preferences"
-            # Work-related: role, organization, department, responsibilities
-            - "work_info"
-            # Personal information: name, location, contact preferences
-            - "personal_info"
-            # Current projects, research topics, ongoing investigations
-            - "projects"
-            # Fact-checking specific: methods, verification approaches, source preferences
-            - "factcheck_info"
-            # Research context: background info, historical context, related investigations
-            - "research_context"
-            # Preferred sources, verification methods, trusted outlets
-            - "sources"
-            # Output format preferences: article style, citation format, structure
-            - "output_format"
-            # Important deadlines, publication dates, milestones
-            - "deadlines"
-            # Expertise areas, specializations, domain knowledge
-            - "expertise"
-            # Final results, conclusions, verified facts from completed fact-checks
-            - "results"
-          agent:
-            provider: "OpenRouter"
-            # Open Source model optimized for Memory tasks with better function calling precision
-            # deepseek/deepseek-chat: Excellent function calling, better at following instructions precisely
-            # Alternative: mistralai/mistral-large-2411 (European, good function calling)
-            model: "deepseek/deepseek-chat"
-            instructions: |
-              Store ONLY substantial, reusable info using validKeys categories. NEVER: greetings, casual chat, trivial mentions, obvious statements. Store: preferences (communication style, topics, workflow), work_info (role, org, responsibilities), personal_info (name, location - only if explicitly shared), projects (current research/investigations), factcheck_info (verification methods), research_context (background, related work), sources (preferred outlets), output_format (article style), deadlines (important dates), expertise (specializations), results (verified facts, conclusions). Must be reusable across conversations. Delete outdated/corrected info promptly. If only greetings/casual chat/no substantial info, END IMMEDIATELY without tools. UPDATE STRATEGY: Check existing memories first. If matching category/key exists, UPDATE with `set_memory` by merging old+new info. Only create new if no match. NEVER delete+recreate. Token limit: 2000 per value.
-            model_parameters:
-              # Lower temperature for more precise, deterministic function calling decisions
-              # 0.2 provides better precision for memory task decisions
-              temperature: 0.2
-              # top_p: 0.8 provides controlled sampling - balances precision with flexibility
-              # Lower than 0.9 for more focused token selection in memory tasks
-              top_p: 0.8
-        
-        endpoints:
-          custom:
-            - name: OpenRouter
-              apiKey: "$${OPENROUTER_KEY}"
-              baseURL: "$${OPENROUTER_BASE_URL}"
-              models:
-                # Mix of Open Source and proprietary models - Fallback list if fetch fails or fetch is disabled
-                # Sorted by Top Weekly popularity
-                default: [
-                  "anthropic/claude-sonnet-4.5",      # Top proprietary model
-                  "deepseek/deepseek-v3.2",           # Best Open Source
-                  "google/gemini-2.5-flash-lite",    # Google's lightweight reasoning model, optimized for speed and cost
-                  "meta-llama/llama-3.3-70b-instruct", # Meta's latest, very popular
-                  "openai/gpt-5.2",                   # Latest GPT-5 series
-                  "xiaomi/mimo-v2-flash",             # Popular open-source model
-                  "deepseek/deepseek-chat",           # Excellent for coding
-                  "mistralai/mistral-large-2411",     # European option (French)
-                  "mistralai/mistral-nemo"            # European option (French, smaller)
-                ]
-                fetch: true
-              titleConvo: true
-              summarize: true
-              headers:
-                HTTP-Referer: "$${OPENROUTER_SITE_URL}"
-                X-Title: "$${OPENROUTER_APP_NAME}"
-        
-        # Model Specs: Define default model for new users
-        # This prevents "My Agents" from being selected when users have no agents
-        # Note: Memory function uses a separate model (configured in memory.agent section)
-        # Chat models don't need Function Calling for Memory - Memory works independently
-        # Models sorted by OpenRouter Top Weekly popularity (https://openrouter.ai/models?order=top-weekly)
-        # Mix of Open Source and proprietary models, European models prioritized where available
-        modelSpecs:
-          list:
-            # ==========================================
-            # Vision Models (Open Source)
-            # ==========================================
-            - name: "qwen2.5-vl-72b"
-              label: "Qwen2.5-VL 72B"
-              description: "Höchste Qualität für Gespräche und Bildverständnis. Kann Bilder analysieren und gleichzeitig natürlich chatten. Von Qwen."
-              group: "Vision Models (Open Source)"
-              groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWV5ZS1pY29uIGx1Y2lkZS1leWUiPjxwYXRoIGQ9Ik0yLjA2MiAxMi4zNDhhMSAxIDAgMCAxIDAtLjY5NiAxMC43NSAxMC43NSAwIDAgMSAxOS44NzYgMCAxIDEgMCAwIDEgMCAuNjk2IDEwLjc1IDEwLjc1IDAgMCAxLTE5Ljg3NiAwIi8+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMyIvPjwvc3ZnPg=="
-              order: 1
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "qwen/qwen2.5-vl-72b-instruct"
-            
-            - name: "qwen2.5-vl-32b"
-              label: "Qwen2.5-VL 32B"
-              description: "Gute Balance aus Qualität und Geschwindigkeit. Versteht Bilder und führt natürliche Gespräche. Von Qwen."
-              group: "Vision Models (Open Source)"
-              order: 2
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "qwen/qwen2.5-vl-32b-instruct"
-            
-            - name: "llama-3.2-vision-90b"
-              label: "Llama 3.2 Vision 90B"
-              description: "Sehr gute Gesprächsqualität mit Bildverständnis. Kann Bilder beschreiben und analysieren. Von Meta (Llama-Serie)."
-              group: "Vision Models (Open Source)"
-              order: 3
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "meta-llama/llama-3.2-90b-vision-instruct"
-            
-            # ==========================================
-            # Vision Models (Proprietary) - Chat Only
-            # ==========================================
-            - name: "google-gemini-2.5-flash-lite"
-              label: "Gemini 2.5 Flash Lite"
-              description: "Schnell und kostengünstig. Optimiert für schnelle Antworten bei guter Qualität. Unterstützt Vision. Von Google."
-              group: "Vision Models (Proprietary)"
-              groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWV5ZS1pY29uIGx1Y2lkZS1leWUiPjxwYXRoIGQ9Ik0yLjA2MiAxMi4zNDhhMSAxIDAgMCAxIDAtLjY5NiAxMC43NSAxMC43NSAwIDAgMSAxOS44NzYgMCAxIDEgMCAwIDEgMCAuNjk2IDEwLjc1IDEwLjc1IDAgMCAxLTE5Ljg3NiAwIi8+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMyIvPjwvc3ZnPg=="
-              order: 1
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "google/gemini-2.5-flash-lite"
-            
-            # ==========================================
-            # Universal Models (Proprietary) - Vision + Tools
-            # ==========================================
-            - name: "claude-sonnet-4.5"
-              label: "Claude Sonnet 4.5"
-              description: "Eines der besten Modelle für komplexe Aufgaben und Programmierung. Optimiert für praktische Anwendungen. Unterstützt Vision und Tools. Von Anthropic."
-              group: "Universal Models (Proprietary)"
-              groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWJvdC1pY29uIGx1Y2lkZS1ib3QiPjxwYXRoIGQ9Ik0xMiA4VjRIOCIvPjxyZWN0IHdpZHRoPSIxNiIgaGVpZ2h0PSIxMiIgeD0iNCIgeT0iOCIgcng9IjIiLz48cGF0aCBkPSJNMiAxNGgyIi8+PHBhdGggZD0iTTIwIDE0aDIiLz48cGF0aCBkPSJNMTUgMTN2MiIvPjxwYXRoIGQ9Ik05IDEzdjIiLz48L3N2Zz4="
-              order: 1
-              webSearch: true
-              fileSearch: true
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "anthropic/claude-sonnet-4.5"
-            
-            # ==========================================
-            # Text Models (Open Source) - Chat Only
-            # ==========================================
-            - name: "llama-3.1-8b"
-              label: "Llama 3.1 8B"
-              description: "Schnell und effizient. Gute Wahl für schnelle Antworten. Von Meta (Llama-Serie)."
-              group: "Text Models (Open Source)"
-              groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW1lc3NhZ2Utc3F1YXJlLWljb24gbHVjaWRlLW1lc3NhZ2Utc3F1YXJlIj48cGF0aCBkPSJNMjIgMTdhMiAyIDAgMCAxLTIgMkg2LjgyOGEyIDIgMCAwIDAtMS40MTQuNTg2bC0yLjIwMiAyLjIwMkEuNzEuNzEgMCAwIDEgMiAyMS4yODZWNWEyIDIgMCAwIDEgMi0yaDE2YTIgMiAwIDAgMSAyIDJ6Ii8+PC9zdmc+"
-              order: 1
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "meta-llama/llama-3.1-8b-instruct"
-            
-            # ==========================================
-            # Text Models with Tools (Open Source)
-            # ==========================================
-            - name: "deepseek-v3.2"
-              label: "DeepSeek V3.2"
-              description: "Kann sehr lange Gespräche führen und komplexe Aufgaben lösen. Sehr gut im logischen Denken. Von DeepSeek."
-              group: "Text Models with Tools (Open Source)"
-              groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWJvdC1tZXNzYWdlLXNxdWFyZS1pY29uIGx1Y2lkZS1ib3QtbWVzc2FnZS1zcXVhcmUiPjxwYXRoIGQ9Ik0xMiA2VjJIOCIvPjxwYXRoIGQ9Ik0xNSAxMXYyIi8+PHBhdGggZD0iTTIgMTJoMiIvPjxwYXRoIGQ9Ik0yMCAxMmgyIi8+PHBhdGggZD0iTTIwIDE2YTIgMiAwIDAgMS0yIDJIOC44MjhhMiAyIDAgMCAwLTEuNDE0LjU4NmwtMi4yMDIgMi4yMDJBLjcxLjcxIDAgMCAxIDQgMjAuMjg2VjhhMiAyIDAgMCAxIDItMmgxMmEyIDIgMCAwIDEgMiAyeiIvPjxwYXRoIGQ9Ik05IDExdjIiLz48L3N2Zz4="
-              order: 1
-              default: true
-              webSearch: true
-              fileSearch: true
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "deepseek/deepseek-v3.2"
-            
-            - name: "llama-3.3-70b"
-              label: "Llama 3.3 70B"
-              description: "Sehr beliebt für allgemeine Gespräche und Aufgaben. Von Meta (Llama-Serie)."
-              group: "Text Models with Tools (Open Source)"
-              order: 2
-              webSearch: true
-              fileSearch: true
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "meta-llama/llama-3.3-70b-instruct"
-            
-            - name: "xiaomi-mimo-v2-flash"
-              label: "MiMo-V2-Flash"
-              description: "Kann sehr lange Gespräche führen. Besonders gut für Wissensthemen, Wissenschaft und Finanzen. Von Xiaomi."
-              group: "Text Models with Tools (Open Source)"
-              order: 3
-              webSearch: true
-              fileSearch: true
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "xiaomi/mimo-v2-flash"
-            
-            - name: "deepseek-chat-67b"
-              label: "DeepSeek Chat 67B"
-              description: "Sehr beliebt, besonders gut für Programmierung und Code-Erstellung. Von DeepSeek."
-              group: "Text Models with Tools (Open Source)"
-              order: 4
-              webSearch: true
-              fileSearch: true
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "deepseek/deepseek-chat"
-            
-            # ==========================================
-            # Text Models (Proprietary) - Chat Only
-            # ==========================================
-            - name: "openai-gpt5-mini"
-              label: "GPT-5 Mini"
-              description: "Schnell und effizient, dabei hochwertige Antworten. Optimiert für Geschwindigkeit. Von OpenAI (GPT-5-Serie)."
-              group: "Text Models (Proprietary)"
-              groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW1lc3NhZ2Utc3F1YXJlLWxvY2staWNvbiBsdWNpZGUtbWVzc2FnZS1zcXVhcmUtbG9jayI+PHBhdGggZD0iTTIyIDguNVY1YTIgMiAwIDAgMC0yLTJINGEyIDIgMCAwIDAtMiAydjE2LjI4NmEuNzEuNzEgMCAwIDAgMS4yMTIuNTAybDIuMjAyLTIuMjAyQTIgMiAwIDAgMSA2LjgyOCAxOUgxMCIvPjxwYXRoIGQ9Ik0yMCAxNXYtMmEyIDIgMCAwIDAtNCAwdjIiLz48cmVjdCB4PSIxNCIgeT0iMTUiIHdpZHRoPSI4IiBoZWlnaHQ9IjUiIHJ4PSIxIi8+PC9zdmc+"
-              order: 1
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "openai/gpt-5-mini"
-            
-            - name: "mistral-nemo"
-              label: "Mistral Nemo"
-              description: "Unterstützt mehrere Sprachen. Von Mistral und NVIDIA. Europäisches Unternehmen (französisch)."
-              group: "Text Models (Proprietary)"
-              order: 2
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "mistralai/mistral-nemo"
-            
-            # ==========================================
-            # Text Models with Tools (Proprietary)
-            # ==========================================
-            - name: "openai-gpt5-2"
-              label: "GPT-5.2"
-              description: "Sehr gut für komplexe Aufgaben und mehrstufige Problemlösung. Von OpenAI (GPT-5-Serie)."
-              group: "Text Models with Tools (Proprietary)"
-              groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWJvdC1tZXNzYWdlLXNxdWFyZS1pY29uIGx1Y2lkZS1ib3QtbWVzc2FnZS1zcXVhcmUiPjxwYXRoIGQ9Ik0xMiA2VjJIOCIvPjxwYXRoIGQ9Ik0xNSAxMXYyIi8+PHBhdGggZD0iTTIgMTJoMiIvPjxwYXRoIGQ9Ik0yMCAxMmgyIi8+PHBhdGggZD0iTTIwIDE2YTIgMiAwIDAgMS0yIDJIOC44MjhhMiAyIDAgMCAwLTEuNDE0LjU4NmwtMi4yMDIgMi4yMDJBLjcxLjcxIDAgMCAxIDQgMjAuMjg2VjhhMiAyIDAgMCAxIDItMmgxMmEyIDIgMCAwIDEgMiAyeiIvPjxwYXRoIGQ9Ik05IDExdjIiLz48L3N2Zz4="
-              order: 1
-              webSearch: true
-              fileSearch: true
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "openai/gpt-5.2"
-            
-            - name: "mistral-large-2411"
-              label: "Mistral Large 2411"
-              description: "Sehr beliebt bei europäischen Nutzern. Von Mistral. Europäisches Unternehmen (französisch)."
-              group: "Text Models with Tools (Proprietary)"
-              order: 2
-              webSearch: true
-              fileSearch: true
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "mistralai/mistral-large-2411"
-            
-            - name: "z-ai-glm-4.7"
-              label: "GLM 4.7"
-              description: "Sehr gut im logischen Denken und komplexen Aufgaben. Fortgeschrittenes Sprachverständnis. Von Z.AI."
-              group: "Text Models with Tools (Proprietary)"
-              order: 3
-              webSearch: true
-              fileSearch: true
-              preset:
-                endpoint: "OpenRouter"
-                endpointType: "custom"
-                model: "glm/glm-4.7"
-
-        
-        webSearch:
-          enabled: true
-          searchProvider: "searxng"
-          searxngInstanceUrl: "$${LIBRECHAT_SEARXNG_URL}"
-          searxngApiKey: "$${LIBRECHAT_SEARXNG_API_KEY}"
-          scraperProvider: "firecrawl"
-          firecrawlApiKey: "$${FIRECRAWL_API_KEY}"
-          firecrawlApiUrl: "$${FIRECRAWL_API_URL}"
-          firecrawlVersion: "$${FIRECRAWL_VERSION}"
-          jinaApiKey: "$${LIBRECHAT_JINA_API_KEY}"
-          jinaApiUrl: "$${LIBRECHAT_JINA_API_URL}"
-          rerankerType: "jina"
-          scraperTimeout: 7500
-          safeSearch: 1
-        
-        registration:
-          allowedDomains:
-            - correctiv.org
-            - faktenforum.org
-          # Optional: Social Login Providers (default: all disabled)
-          # socialLogins: ['github', 'google', 'discord', 'openid', 'facebook', 'apple', 'saml']
-        
-        # Balance System (disabled - for cost-based limits)
-        # balance:
-        #   enabled: false
-        #   startBalance: 20000        # Starting balance for new users
-        #   autoRefillEnabled: false   # Automatic refill
-        #   refillIntervalValue: 30    # Interval value
-        #   refillIntervalUnit: 'days' # Interval unit (days, weeks, months)
-        #   refillAmount: 10000        # Refill amount
-        
-        # Transactions (disabled - for transaction logs)
-        # Default: true (enabled), automatically enabled when balance.enabled: true
-        # transactions:
-        #   enabled: false
-        
-        # Speech / Voice Features (disabled - TTS/STT)
-        # speech:
-        #   tts:
-        #     openai:
-        #       url: ''
-        #       apiKey: '${TTS_API_KEY}'
-        #       model: ''
-        #       voices: ['']
-        #   stt:
-        #     openai:
-        #       url: ''
-        #       apiKey: '${STT_API_KEY}'
-        #       model: ''
-        
-        # Cloudflare Turnstile CAPTCHA (disabled)
-        # turnstile:
-        #   siteKey: "your-site-key-here"
-        #   options:
-        #     language: "auto"    # "auto" or ISO 639-1 code (e.g. "de")
-        #     size: "normal"      # "normal", "compact", "flexible", "invisible"
-        
-        # Rate Limits (disabled - for upload/import limits)
-        # rateLimits:
-        #   fileUploads:
-        #     ipMax: 100                    # Max uploads per IP
-        #     ipWindowInMinutes: 60         # Time window for IP limit
-        #     userMax: 50                   # Max uploads per user
-        #     userWindowInMinutes: 60       # Time window for user limit
-        #   conversationsImport:
-        #     ipMax: 100                    # Max imports per IP
-        #     ipWindowInMinutes: 60         # Time window for IP limit
-        #     userMax: 50                   # Max imports per user
-        #     userWindowInMinutes: 60       # Time window for user limit
-        
-        # File Config (disabled - granular upload configuration)
-        # fileConfig:
-        #   endpoints:
-        #     assistants:
-        #       fileLimit: 5                # Max files per request
-        #       fileSizeLimit: 10           # Max size per file (MB)
-        #       totalSizeLimit: 50          # Max total size (MB)
-        #       supportedMimeTypes:
-        #         - "image/.*"
-        #         - "application/pdf"
-        #     openAI:
-        #       disabled: true              # Disables uploads for OpenAI endpoint
-        #     default:
-        #       totalSizeLimit: 20          # Default total size (MB)
-        #   serverFileSizeLimit: 100        # Global server limit (MB)
-        #   avatarSizeLimit: 2              # Avatar size limit (MB)
-        #   imageGeneration:
-        #     percentage: 100               # Image size in percentage
-        #     px: 1024                      # Image size in pixels
-        #   clientImageResize:
-        #     enabled: false                # Client-side image compression
-        #     maxWidth: 1900                # Max width (px)
-        #     maxHeight: 1900               # Max height (px)
-        #     quality: 0.92                 # JPEG quality (0.0-1.0)
-        
-        # MCP Servers Interface Config (default: use: true, create: true, share: false)
-        # interface:
-        #   mcpServers:
-        #     use: true       # Users can use MCP servers (default: true)
-        #     create: true    # Users can create MCP servers (default: true)
-        #     share: false    # Users can share MCP servers (default: false)
-        
-        # Temporary Chat Retention (disabled - automatic deletion)
-        # interface:
-        #   temporaryChatRetention: 720  # Hours (min: 1, max: 8760, default: 720 = 30 days)
-        
-        # Actions Domain Restrictions (disabled - SSRF protection for Agent Actions)
-        # SECURITY: If not configured, SSRF targets are blocked (localhost, private IPs, .internal/.local TLDs)
-        # To allow internal targets, they MUST be explicitly added to allowedDomains
-        # Supports wildcards: '*.example.com' and protocol/port restrictions: 'https://api.example.com:8443'
-        # actions:
-        #   allowedDomains:
-        #     - 'swapi.dev'
-        #     - 'librechat.ai'
-        #     - 'google.com'
-        #     # - 'http://10.225.26.25:7894'  # Internal IP with protocol/port (uncomment if needed)
-        
-        # MCP Settings (disabled - SSRF protection for MCP Server Remote Transports)
-        # SECURITY: If not configured, SSRF targets are blocked (localhost, private IPs, .internal/.local TLDs)
-        # To allow internal targets like host.docker.internal, they MUST be explicitly added
-        # Supports wildcards: '*.example.com' matches 'api.example.com', 'staging.example.com', etc.
-        # Supports protocol/port restrictions: 'https://api.example.com:8443'
-        # mcpSettings:
-        #   allowedDomains:
-        #     - 'host.docker.internal'    # Docker host access (required for Docker setups)
-        #     - 'localhost'               # Local development
-        #     - '*.example.com'           # Wildcard subdomain
-        #     - 'https://secure.api.com'  # Protocol-restricted
-        #     - 'http://internal:8080'    # Protocol and port restricted
-        
-        # OCR Configuration (disabled - Optical Character Recognition)
-        # ocr:
-        #   mistralModel: ""         # Mistral model for OCR (optional)
-        #   apiKey: "${OCR_API_KEY}" # API key (default: "${OCR_API_KEY}")
-        #   baseURL: "${OCR_BASEURL}" # Base URL (default: "${OCR_BASEURL}")
-        #   strategy: "mistral_ocr"  # Strategy: "mistral_ocr", "custom_ocr", "azure_mistral_ocr", "vertexai_mistral_ocr" (default: "mistral_ocr")
-        
-        # File Strategy (Granular) - disabled (default: "local" for all file types)
-        # Allows different storage strategies for different file types
-        # If not specified, all file types default to "local"
-        # Priority: specific type > fileStrategies.default > fileStrategy > "local"
-        # Available strategies: "local", "s3", "firebase", "azure_blob"
-        fileStrategies:
-          default: "local"
-          avatar: "local"
-          image: "local"
-          document: "local"
-        CONFIG_EOF
-        
-        echo "✓ Config generated successfully"
-        echo "  LibreChat will resolve environment variables at runtime"
-        echo ""
-        echo "Preview (first 10 lines):"
-        head -10 /app/config/librechat.yaml
+      - ./logs:/logs
+      - ./images:/images
+      - ./uploads:/uploads
+      - ./data-node:/mongo_data
+      - ./meili_data_v1.12:/meili_data
+      - mongoconfig:/mongo_configdb
+    depends_on:
+      mongodb:
+        condition: service_healthy
     networks:
       - app-net
 
@@ -533,9 +74,7 @@ services:
       - ./logs:/app/logs
       - librechat-config:/app/config:ro
     depends_on:
-      config-init:
-        condition: service_completed_successfully
-      setup-permissions:
+      librechat-init:
         condition: service_completed_successfully
       mongodb:
         condition: service_started
@@ -556,13 +95,16 @@ services:
     image: mongo
     restart: always
     user: "${UID:-1000}:${GID:-1000}"
-    depends_on:
-      setup-permissions:
-        condition: service_completed_successfully
     volumes:
       - ./data-node:/data/db
       - mongoconfig:/data/configdb
     command: mongod --noauth
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     networks:
       - app-net
 
@@ -580,24 +122,12 @@ services:
     networks:
       - app-net
 
-  setup-permissions:
-    image: alpine
-    restart: "no"
-    container_name: setup-permissions
-    user: root
-    volumes:
-      - ./logs:/logs
-      - ./images:/images
-      - ./uploads:/uploads
-      - ./data-node:/mongo_data
-      - ./meili_data_v1.12:/meili_data
-      - mongoconfig:/mongo_configdb
-    command: >
-      sh -c "chown -R ${UID:-1000}:${GID:-1000} /logs /images /uploads /mongo_data /mongo_configdb /meili_data && 
-             chmod -R 775 /logs /images /uploads /mongo_data /mongo_configdb /meili_data"
-    networks:
-      - app-net
-
 volumes:
   librechat-config:
   mongoconfig:
+
+networks:
+  app-net:
+    driver: bridge
+  traefik-net:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,6 @@ services:
       - "traefik.http.routers.maildev.entrypoints=web"
       - "traefik.http.services.maildev.loadbalancer.server.port=1080"
 
-  config-init:
-    extends: { file: docker-compose.librechat.yml, service: config-init }
-    env_file: .env
-
   mongodb:
     extends: { file: docker-compose.librechat.yml, service: mongodb }
     env_file: .env
@@ -35,8 +31,8 @@ services:
     extends: { file: docker-compose.librechat.yml, service: api }
     env_file: .env
 
-  setup-permissions:
-    extends: { file: docker-compose.librechat.yml, service: setup-permissions }
+  librechat-init:
+    extends: { file: docker-compose.librechat.yml, service: librechat-init }
     env_file: .env
 
   openwebui:

--- a/env.example
+++ b/env.example
@@ -61,6 +61,9 @@ LIBRECHAT_VECTORDB_PASSWORD=
 
 # LibreChat - Registration & Authentication
 LIBRECHAT_ALLOW_REGISTRATION=true
+# LibreChat - Default Administrators (comma-separated email addresses)
+# Users with these email addresses will automatically be assigned the ADMIN role
+LIBRECHAT_DEFAULT_ADMINS=
 # Set to false in production to disable self-registration
 # Users can then be created manually via: docker exec -it LibreChat npm run create-user
 LIBRECHAT_ALLOW_UNVERIFIED_EMAIL_LOGIN=false

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "ai-chat-interface",
     "description": "Infrastructure for AI Chat Interface with Traefik, LibreChat, and more",
     "type": "module",
+    "workspaces": [
+        "packages/*"
+    ],
     "scripts": {
         "setup": "./scripts/setup-env.ts",
         "setup:yes": "./scripts/setup-env.ts --yes",

--- a/packages/librechat-init/Dockerfile
+++ b/packages/librechat-init/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:24
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json package-lock.json* ./
+COPY tsconfig.json ./
+COPY config/ ./config/
+COPY src/ ./src/
+
+# Install production dependencies
+RUN npm install --production --silent
+
+# Run with TypeScript support (like setup-env.ts)
+CMD ["node", "--experimental-strip-types", "--no-warnings", "src/init.ts"]

--- a/packages/librechat-init/README.md
+++ b/packages/librechat-init/README.md
@@ -1,0 +1,66 @@
+# LibreChat Init Service
+
+Unified initialization service for LibreChat that handles:
+1. LibreChat YAML configuration setup
+2. File permissions configuration
+3. MongoDB role initialization
+
+## Structure
+
+```
+librechat-init/
+├── config/
+│   ├── librechat.yaml    # LibreChat configuration file
+│   └── roles.json        # Custom roles definition
+├── src/
+│   ├── init.ts           # Main orchestrator
+│   ├── setup-permissions.ts
+│   └── init-roles.ts
+├── package.json
+├── tsconfig.json
+└── Dockerfile
+```
+
+## Configuration
+
+### Custom Roles
+
+Edit `config/roles.json` to add or modify custom roles:
+
+```json
+{
+  "roles": [
+    {
+      "name": "DEVELOPER",
+      "permissions": {
+        "PROMPTS": { "SHARED_GLOBAL": true, "USE": true, "CREATE": true },
+        ...
+      }
+    }
+  ]
+}
+```
+
+### Default Administrators
+
+Set `LIBRECHAT_DEFAULT_ADMINS` environment variable (comma-separated email addresses):
+
+```bash
+LIBRECHAT_DEFAULT_ADMINS=admin@example.com,admin2@example.com
+```
+
+## Building
+
+```bash
+npm run build:docker
+```
+
+Or via Docker Compose:
+
+```bash
+docker compose -f docker-compose.librechat.yml build librechat-init
+```
+
+## Usage
+
+The service runs automatically as part of the Docker Compose stack. It executes before the LibreChat API service starts.

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -1,0 +1,464 @@
+version: 1.3.1
+cache: true
+
+interface:
+  customWelcome: 'Hi {{user.name}}! Willkommen im KI Chat-Interface von Correctiv mit LibreChat'
+  fileSearch: true
+  privacyPolicy:
+    externalUrl: 'https://correctiv.org/kontakt/datenschutz/'
+    openNewTab: true
+  termsOfService:
+    externalUrl: 'https://correctiv.org'
+    openNewTab: true
+    modalAcceptance: true
+    modalTitle: 'Kleingedrucktes'
+    modalContent: |
+      # Nutzungsbedingungen
+
+      **Wichtiger Hinweis zu KI-generierten Antworten**
+      Alle Antworten dieses KI-Systems sollten stets von Menschen überprüft werden. KI-generierte Inhalte können Fehler enthalten und sollten nicht als alleinige Quelle für wichtige Entscheidungen verwendet werden.
+
+      **Datenverarbeitung und Hosting**
+      Wir bemühen uns, so viele Komponenten wie möglich selbst zu hosten. Aktuell nutzen wir noch externe Dienste wie OpenRouter, wodurch Daten derzeit an Server in den USA übertragen werden. Unser Ziel ist es, vollständig auf selbst gehostete oder europäische Dienste umzustellen.
+  endpointsMenu: true
+  modelSelect: true
+  parameters: true
+  sidePanel: true
+  presets: true
+  prompts: true
+  bookmarks: true
+  multiConvo: true
+  agents: true
+  peoplePicker:
+    users: true
+    groups: true
+    roles: true
+  marketplace:
+    use: true
+  fileCitations: true
+  search: true
+
+memory:
+  disabled: false
+  personalize: true
+  tokenLimit: 2000
+  messageWindowSize: 5
+  # Memory categories for journalism and fact-checking workflow
+  # Restricts memory storage to these structured categories for better consistency
+  validKeys:
+    # User preferences and communication style
+    - "preferences"
+    # Work-related: role, organization, department, responsibilities
+    - "work_info"
+    # Personal information: name, location, contact preferences
+    - "personal_info"
+    # Current projects, research topics, ongoing investigations
+    - "projects"
+    # Fact-checking specific: methods, verification approaches, source preferences
+    - "factcheck_info"
+    # Research context: background info, historical context, related investigations
+    - "research_context"
+    # Preferred sources, verification methods, trusted outlets
+    - "sources"
+    # Output format preferences: article style, citation format, structure
+    - "output_format"
+    # Important deadlines, publication dates, milestones
+    - "deadlines"
+    # Expertise areas, specializations, domain knowledge
+    - "expertise"
+    # Final results, conclusions, verified facts from completed fact-checks
+    - "results"
+  agent:
+    provider: "OpenRouter"
+    # Open Source model optimized for Memory tasks with better function calling precision
+    # deepseek/deepseek-chat: Excellent function calling, better at following instructions precisely
+    # Alternative: mistralai/mistral-large-2411 (European, good function calling)
+    model: "deepseek/deepseek-chat"
+    instructions: |
+      Store ONLY substantial, reusable info using validKeys categories. NEVER: greetings, casual chat, trivial mentions, obvious statements. Store: preferences (communication style, topics, workflow), work_info (role, org, responsibilities), personal_info (name, location - only if explicitly shared), projects (current research/investigations), factcheck_info (verification methods), research_context (background, related work), sources (preferred outlets), output_format (article style), deadlines (important dates), expertise (specializations), results (verified facts, conclusions). Must be reusable across conversations. Delete outdated/corrected info promptly. If only greetings/casual chat/no substantial info, END IMMEDIATELY without tools. UPDATE STRATEGY: Check existing memories first. If matching category/key exists, UPDATE with `set_memory` by merging old+new info. Only create new if no match. NEVER delete+recreate. Token limit: 2000 per value.
+    model_parameters:
+      # Lower temperature for more precise, deterministic function calling decisions
+      # 0.2 provides better precision for memory task decisions
+      temperature: 0.2
+      # top_p: 0.8 provides controlled sampling - balances precision with flexibility
+      # Lower than 0.9 for more focused token selection in memory tasks
+      top_p: 0.8
+
+endpoints:
+  custom:
+    - name: OpenRouter
+      apiKey: "$${OPENROUTER_KEY}"
+      baseURL: "$${OPENROUTER_BASE_URL}"
+      models:
+        # Mix of Open Source and proprietary models - Fallback list if fetch fails or fetch is disabled
+        # Sorted by Top Weekly popularity
+        default: [
+          "anthropic/claude-sonnet-4.5",      # Top proprietary model
+          "deepseek/deepseek-v3.2",           # Best Open Source
+          "google/gemini-2.5-flash-lite",    # Google's lightweight reasoning model, optimized for speed and cost
+          "meta-llama/llama-3.3-70b-instruct", # Meta's latest, very popular
+          "openai/gpt-5.2",                   # Latest GPT-5 series
+          "xiaomi/mimo-v2-flash",             # Popular open-source model
+          "deepseek/deepseek-chat",           # Excellent for coding
+          "mistralai/mistral-large-2411",     # European option (French)
+          "mistralai/mistral-nemo"            # European option (French, smaller)
+        ]
+        fetch: true
+      titleConvo: true
+      summarize: true
+      headers:
+        HTTP-Referer: "$${OPENROUTER_SITE_URL}"
+        X-Title: "$${OPENROUTER_APP_NAME}"
+
+# Model Specs: Define default model for new users
+# This prevents "My Agents" from being selected when users have no agents
+# Note: Memory function uses a separate model (configured in memory.agent section)
+# Chat models don't need Function Calling for Memory - Memory works independently
+# Models sorted by OpenRouter Top Weekly popularity (https://openrouter.ai/models?order=top-weekly)
+# Mix of Open Source and proprietary models, European models prioritized where available
+modelSpecs:
+  list:
+    # ==========================================
+    # Vision Models (Open Source)
+    # ==========================================
+    - name: "qwen2.5-vl-72b"
+      label: "Qwen2.5-VL 72B"
+      description: "Höchste Qualität für Gespräche und Bildverständnis. Kann Bilder analysieren und gleichzeitig natürlich chatten. Von Qwen."
+      group: "Vision Models (Open Source)"
+      groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWV5ZS1pY29uIGx1Y2lkZS1leWUiPjxwYXRoIGQ9Ik0yLjA2MiAxMi4zNDhhMSAxIDAgMCAxIDAtLjY5NiAxMC43NSAxMC43NSAwIDAgMSAxOS44NzYgMCAxIDEgMCAwIDEgMCAuNjk2IDEwLjc1IDEwLjc1IDAgMCAxLTE5Ljg3NiAwIi8+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMyIvPjwvc3ZnPg=="
+      order: 1
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "qwen/qwen2.5-vl-72b-instruct"
+    
+    - name: "qwen2.5-vl-32b"
+      label: "Qwen2.5-VL 32B"
+      description: "Gute Balance aus Qualität und Geschwindigkeit. Versteht Bilder und führt natürliche Gespräche. Von Qwen."
+      group: "Vision Models (Open Source)"
+      order: 2
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "qwen/qwen2.5-vl-32b-instruct"
+    
+    - name: "llama-3.2-vision-90b"
+      label: "Llama 3.2 Vision 90B"
+      description: "Sehr gute Gesprächsqualität mit Bildverständnis. Kann Bilder beschreiben und analysieren. Von Meta (Llama-Serie)."
+      group: "Vision Models (Open Source)"
+      order: 3
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "meta-llama/llama-3.2-90b-vision-instruct"
+    
+    # ==========================================
+    # Vision Models (Proprietary) - Chat Only
+    # ==========================================
+    - name: "google-gemini-2.5-flash-lite"
+      label: "Gemini 2.5 Flash Lite"
+      description: "Schnell und kostengünstig. Optimiert für schnelle Antworten bei guter Qualität. Unterstützt Vision. Von Google."
+      group: "Vision Models (Proprietary)"
+      groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWV5ZS1pY29uIGx1Y2lkZS1leWUiPjxwYXRoIGQ9Ik0yLjA2MiAxMi4zNDhhMSAxIDAgMCAxIDAtLjY5NiAxMC43NSAxMC43NSAwIDAgMSAxOS44NzYgMCAxIDEgMCAwIDEgMCAuNjk2IDEwLjc1IDEwLjc1IDAgMCAxLTE5Ljg3NiAwIi8+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMyIvPjwvc3ZnPg=="
+      order: 1
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "google/gemini-2.5-flash-lite"
+    
+    # ==========================================
+    # Universal Models (Proprietary) - Vision + Tools
+    # ==========================================
+    - name: "claude-sonnet-4.5"
+      label: "Claude Sonnet 4.5"
+      description: "Eines der besten Modelle für komplexe Aufgaben und Programmierung. Optimiert für praktische Anwendungen. Unterstützt Vision und Tools. Von Anthropic."
+      group: "Universal Models (Proprietary)"
+      groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWJvdC1pY29uIGx1Y2lkZS1ib3QiPjxwYXRoIGQ9Ik0xMiA4VjRIOCIvPjxyZWN0IHdpZHRoPSIxNiIgaGVpZ2h0PSIxMiIgeD0iNCIgeT0iOCIgcng9IjIiLz48cGF0aCBkPSJNMiAxNGgyIi8+PHBhdGggZD0iTTIwIDE0aDIiLz48cGF0aCBkPSJNMTUgMTN2MiIvPjxwYXRoIGQ9Ik05IDEzdjIiLz48L3N2Zz4="
+      order: 1
+      webSearch: true
+      fileSearch: true
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "anthropic/claude-sonnet-4.5"
+    
+    # ==========================================
+    # Text Models (Open Source) - Chat Only
+    # ==========================================
+    - name: "llama-3.1-8b"
+      label: "Llama 3.1 8B"
+      description: "Schnell und effizient. Gute Wahl für schnelle Antworten. Von Meta (Llama-Serie)."
+      group: "Text Models (Open Source)"
+      groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW1lc3NhZ2Utc3F1YXJlLWljb24gbHVjaWRlLW1lc3NhZ2Utc3F1YXJlIj48cGF0aCBkPSJNMjIgMTdhMiAyIDAgMCAxLTIgMkg2LjgyOGEyIDIgMCAwIDAtMS40MTQuNTg2bC0yLjIwMiAyLjIwMkEuNzEuNzEgMCAwIDEgMiAyMS4yODZWNWEyIDIgMCAwIDEgMi0yaDE2YTIgMiAwIDAgMSAyIDJ6Ii8+PC9zdmc+"
+      order: 1
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "meta-llama/llama-3.1-8b-instruct"
+    
+    # ==========================================
+    # Text Models with Tools (Open Source)
+    # ==========================================
+    - name: "deepseek-v3.2"
+      label: "DeepSeek V3.2"
+      description: "Kann sehr lange Gespräche führen und komplexe Aufgaben lösen. Sehr gut im logischen Denken. Von DeepSeek."
+      group: "Text Models with Tools (Open Source)"
+      groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWJvdC1tZXNzYWdlLXNxdWFyZS1pY29uIGx1Y2lkZS1ib3QtbWVzc2FnZS1zcXVhcmUiPjxwYXRoIGQ9Ik0xMiA2VjJIOCIvPjxwYXRoIGQ9Ik0xNSAxMXYyIi8+PHBhdGggZD0iTTIgMTJoMiIvPjxwYXRoIGQ9Ik0yMCAxMmgyIi8+PHBhdGggZD0iTTIwIDE2YTIgMiAwIDAgMS0yIDJIOC44MjhhMiAyIDAgMCAwLTEuNDE0LjU4NmwtMi4yMDIgMi4yMDJBLjcxLjcxIDAgMCAxIDQgMjAuMjg2VjhhMiAyIDAgMCAxIDItMmgxMmEyIDIgMCAwIDEgMiAyeiIvPjxwYXRoIGQ9Ik05IDExdjIiLz48L3N2Zz4="
+      order: 1
+      default: true
+      webSearch: true
+      fileSearch: true
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "deepseek/deepseek-v3.2"
+    
+    - name: "llama-3.3-70b"
+      label: "Llama 3.3 70B"
+      description: "Sehr beliebt für allgemeine Gespräche und Aufgaben. Von Meta (Llama-Serie)."
+      group: "Text Models with Tools (Open Source)"
+      order: 2
+      webSearch: true
+      fileSearch: true
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "meta-llama/llama-3.3-70b-instruct"
+    
+    - name: "xiaomi-mimo-v2-flash"
+      label: "MiMo-V2-Flash"
+      description: "Kann sehr lange Gespräche führen. Besonders gut für Wissensthemen, Wissenschaft und Finanzen. Von Xiaomi."
+      group: "Text Models with Tools (Open Source)"
+      order: 3
+      webSearch: true
+      fileSearch: true
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "xiaomi/mimo-v2-flash"
+    
+    - name: "deepseek-chat-67b"
+      label: "DeepSeek Chat 67B"
+      description: "Sehr beliebt, besonders gut für Programmierung und Code-Erstellung. Von DeepSeek."
+      group: "Text Models with Tools (Open Source)"
+      order: 4
+      webSearch: true
+      fileSearch: true
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "deepseek/deepseek-chat"
+    
+    # ==========================================
+    # Text Models (Proprietary) - Chat Only
+    # ==========================================
+    - name: "openai-gpt5-mini"
+      label: "GPT-5 Mini"
+      description: "Schnell und effizient, dabei hochwertige Antworten. Optimiert für Geschwindigkeit. Von OpenAI (GPT-5-Serie)."
+      group: "Text Models (Proprietary)"
+      groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW1lc3NhZ2Utc3F1YXJlLWxvY2staWNvbiBsdWNpZGUtbWVzc2FnZS1zcXVhcmUtbG9jayI+PHBhdGggZD0iTTIyIDguNVY1YTIgMiAwIDAgMC0yLTJINGEyIDIgMCAwIDAtMiAydjE2LjI4NmEuNzEuNzEgMCAwIDAgMS4yMTIuNTAybDIuMjAyLTIuMjAyQTIgMiAwIDAgMSA2LjgyOCAxOUgxMCIvPjxwYXRoIGQ9Ik0yMCAxNXYtMmEyIDIgMCAwIDAtNCAwdjIiLz48cmVjdCB4PSIxNCIgeT0iMTUiIHdpZHRoPSI4IiBoZWlnaHQ9IjUiIHJ4PSIxIi8+PC9zdmc+"
+      order: 1
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "openai/gpt-5-mini"
+    
+    - name: "mistral-nemo"
+      label: "Mistral Nemo"
+      description: "Unterstützt mehrere Sprachen. Von Mistral und NVIDIA. Europäisches Unternehmen (französisch)."
+      group: "Text Models (Proprietary)"
+      order: 2
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "mistralai/mistral-nemo"
+    
+    # ==========================================
+    # Text Models with Tools (Proprietary)
+    # ==========================================
+    - name: "openai-gpt5-2"
+      label: "GPT-5.2"
+      description: "Sehr gut für komplexe Aufgaben und mehrstufige Problemlösung. Von OpenAI (GPT-5-Serie)."
+      group: "Text Models with Tools (Proprietary)"
+      groupIcon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWJvdC1tZXNzYWdlLXNxdWFyZS1pY29uIGx1Y2lkZS1ib3QtbWVzc2FnZS1zcXVhcmUiPjxwYXRoIGQ9Ik0xMiA2VjJIOCIvPjxwYXRoIGQ9Ik0xNSAxMXYyIi8+PHBhdGggZD0iTTIgMTJoMiIvPjxwYXRoIGQ9Ik0yMCAxMmgyIi8+PHBhdGggZD0iTTIwIDE2YTIgMiAwIDAgMS0yIDJIOC44MjhhMiAyIDAgMCAwLTEuNDE0LjU4NmwtMi4yMDIgMi4yMDJBLjcxLjcxIDAgMCAxIDQgMjAuMjg2VjhhMiAyIDAgMCAxIDItMmgxMmEyIDIgMCAwIDEgMiAyeiIvPjxwYXRoIGQ9Ik05IDExdjIiLz48L3N2Zz4="
+      order: 1
+      webSearch: true
+      fileSearch: true
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "openai/gpt-5.2"
+    
+    - name: "mistral-large-2411"
+      label: "Mistral Large 2411"
+      description: "Sehr beliebt bei europäischen Nutzern. Von Mistral. Europäisches Unternehmen (französisch)."
+      group: "Text Models with Tools (Proprietary)"
+      order: 2
+      webSearch: true
+      fileSearch: true
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "mistralai/mistral-large-2411"
+    
+    - name: "z-ai-glm-4.7"
+      label: "GLM 4.7"
+      description: "Sehr gut im logischen Denken und komplexen Aufgaben. Fortgeschrittenes Sprachverständnis. Von Z.AI."
+      group: "Text Models with Tools (Proprietary)"
+      order: 3
+      webSearch: true
+      fileSearch: true
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "glm/glm-4.7"
+
+
+webSearch:
+  enabled: true
+  searchProvider: "searxng"
+  searxngInstanceUrl: "$${LIBRECHAT_SEARXNG_URL}"
+  searxngApiKey: "$${LIBRECHAT_SEARXNG_API_KEY}"
+  scraperProvider: "firecrawl"
+  firecrawlApiKey: "$${FIRECRAWL_API_KEY}"
+  firecrawlApiUrl: "$${FIRECRAWL_API_URL}"
+  firecrawlVersion: "$${FIRECRAWL_VERSION}"
+  jinaApiKey: "$${LIBRECHAT_JINA_API_KEY}"
+  jinaApiUrl: "$${LIBRECHAT_JINA_API_URL}"
+  rerankerType: "jina"
+  scraperTimeout: 7500
+  safeSearch: 1
+
+registration:
+  allowedDomains:
+    - correctiv.org
+    - faktenforum.org
+  # Optional: Social Login Providers (default: all disabled)
+  # socialLogins: ['github', 'google', 'discord', 'openid', 'facebook', 'apple', 'saml']
+
+# Balance System (disabled - for cost-based limits)
+# balance:
+#   enabled: false
+#   startBalance: 20000        # Starting balance for new users
+#   autoRefillEnabled: false   # Automatic refill
+#   refillIntervalValue: 30    # Interval value
+#   refillIntervalUnit: 'days' # Interval unit (days, weeks, months)
+#   refillAmount: 10000        # Refill amount
+
+# Transactions (disabled - for transaction logs)
+# Default: true (enabled), automatically enabled when balance.enabled: true
+# transactions:
+#   enabled: false
+
+# Speech / Voice Features (disabled - TTS/STT)
+# speech:
+#   tts:
+#     openai:
+#       url: ''
+#       apiKey: '${TTS_API_KEY}'
+#       model: ''
+#       voices: ['']
+#   stt:
+#     openai:
+#       url: ''
+#       apiKey: '${STT_API_KEY}'
+#       model: ''
+
+# Cloudflare Turnstile CAPTCHA (disabled)
+# turnstile:
+#   siteKey: "your-site-key-here"
+#   options:
+#     language: "auto"    # "auto" or ISO 639-1 code (e.g. "de")
+#     size: "normal"      # "normal", "compact", "flexible", "invisible"
+
+# Rate Limits (disabled - for upload/import limits)
+# rateLimits:
+#   fileUploads:
+#     ipMax: 100                    # Max uploads per IP
+#     ipWindowInMinutes: 60         # Time window for IP limit
+#     userMax: 50                   # Max uploads per user
+#     userWindowInMinutes: 60       # Time window for user limit
+#   conversationsImport:
+#     ipMax: 100                    # Max imports per IP
+#     ipWindowInMinutes: 60         # Time window for IP limit
+#     userMax: 50                   # Max imports per user
+#     userWindowInMinutes: 60       # Time window for user limit
+
+# File Config (disabled - granular upload configuration)
+# fileConfig:
+#   endpoints:
+#     assistants:
+#       fileLimit: 5                # Max files per request
+#       fileSizeLimit: 10           # Max size per file (MB)
+#       totalSizeLimit: 50          # Max total size (MB)
+#       supportedMimeTypes:
+#         - "image/.*"
+#         - "application/pdf"
+#     openAI:
+#       disabled: true              # Disables uploads for OpenAI endpoint
+#     default:
+#       totalSizeLimit: 20          # Default total size (MB)
+#   serverFileSizeLimit: 100        # Global server limit (MB)
+#   avatarSizeLimit: 2              # Avatar size limit (MB)
+#   imageGeneration:
+#     percentage: 100               # Image size in percentage
+#     px: 1024                      # Image size in pixels
+#   clientImageResize:
+#     enabled: false                # Client-side image compression
+#     maxWidth: 1900                # Max width (px)
+#     maxHeight: 1900               # Max height (px)
+#     quality: 0.92                 # JPEG quality (0.0-1.0)
+
+# MCP Servers Interface Config (default: use: true, create: true, share: false)
+# interface:
+#   mcpServers:
+#     use: true       # Users can use MCP servers (default: true)
+#     create: true    # Users can create MCP servers (default: true)
+#     share: false    # Users can share MCP servers (default: false)
+
+# Temporary Chat Retention (disabled - automatic deletion)
+# interface:
+#   temporaryChatRetention: 720  # Hours (min: 1, max: 8760, default: 720 = 30 days)
+
+# Actions Domain Restrictions (disabled - SSRF protection for Agent Actions)
+# SECURITY: If not configured, SSRF targets are blocked (localhost, private IPs, .internal/.local TLDs)
+# To allow internal targets, they MUST be explicitly added to allowedDomains
+# Supports wildcards: '*.example.com' and protocol/port restrictions: 'https://api.example.com:8443'
+# actions:
+#   allowedDomains:
+#     - 'swapi.dev'
+#     - 'librechat.ai'
+#     - 'google.com'
+#     # - 'http://10.225.26.25:7894'  # Internal IP with protocol/port (uncomment if needed)
+
+# MCP Settings (disabled - SSRF protection for MCP Server Remote Transports)
+# SECURITY: If not configured, SSRF targets are blocked (localhost, private IPs, .internal/.local TLDs)
+# To allow internal targets like host.docker.internal, they MUST be explicitly added
+# Supports wildcards: '*.example.com' matches 'api.example.com', 'staging.example.com', etc.
+# Supports protocol/port restrictions: 'https://api.example.com:8443'
+# mcpSettings:
+#   allowedDomains:
+#     - 'host.docker.internal'    # Docker host access (required for Docker setups)
+#     - 'localhost'               # Local development
+#     - '*.example.com'           # Wildcard subdomain
+#     - 'https://secure.api.com'  # Protocol-restricted
+#     - 'http://internal:8080'    # Protocol and port restricted
+
+# OCR Configuration (disabled - Optical Character Recognition)
+# ocr:
+#   mistralModel: ""         # Mistral model for OCR (optional)
+#   apiKey: "${OCR_API_KEY}" # API key (default: "${OCR_API_KEY}")
+#   baseURL: "${OCR_BASEURL}" # Base URL (default: "${OCR_BASEURL}")
+#   strategy: "mistral_ocr"  # Strategy: "mistral_ocr", "custom_ocr", "azure_mistral_ocr", "vertexai_mistral_ocr" (default: "mistral_ocr")
+
+# File Strategy (Granular) - disabled (default: "local" for all file types)
+# Allows different storage strategies for different file types
+# If not specified, all file types default to "local"
+# Priority: specific type > fileStrategies.default > fileStrategy > "local"
+# Available strategies: "local", "s3", "firebase", "azure_blob"
+fileStrategies:
+  default: "local"
+  avatar: "local"
+  image: "local"
+  document: "local"
+CONFIG_EOF

--- a/packages/librechat-init/config/roles.json
+++ b/packages/librechat-init/config/roles.json
@@ -1,0 +1,22 @@
+{
+  "roles": [
+    {
+      "name": "DEVELOPER",
+      "permissions": {
+        "PROMPTS": { "SHARED_GLOBAL": true, "USE": true, "CREATE": true },
+        "AGENTS": { "SHARED_GLOBAL": true, "USE": true, "CREATE": true },
+        "MEMORIES": { "USE": true, "CREATE": true, "UPDATE": true, "READ": true, "OPT_OUT": true },
+        "BOOKMARKS": { "USE": true },
+        "WEB_SEARCH": { "USE": true },
+        "PEOPLE_PICKER": { "VIEW_USERS": true, "VIEW_GROUPS": true, "VIEW_ROLES": true },
+        "MARKETPLACE": { "USE": true },
+        "MCP_SERVERS": { "USE": true, "CREATE": true, "SHARE": true },
+        "FILE_SEARCH": { "USE": true },
+        "FILE_CITATIONS": { "USE": true },
+        "RUN_CODE": { "USE": true },
+        "MULTI_CONVO": { "USE": true },
+        "TEMPORARY_CHAT": { "USE": true }
+      }
+    }
+  ]
+}

--- a/packages/librechat-init/package.json
+++ b/packages/librechat-init/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@ai-chat-interface/librechat-init",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "LibreChat initialization service",
+  "dependencies": {
+    "mongoose": "^8.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.3"
+  },
+  "scripts": {
+    "start": "node --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings src/init.ts",
+    "build:docker": "docker build -t librechat-init:latest ."
+  }
+}

--- a/packages/librechat-init/src/init-roles.ts
+++ b/packages/librechat-init/src/init-roles.ts
@@ -1,0 +1,161 @@
+import mongoose from 'mongoose';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface RolePermissions {
+  PROMPTS?: { SHARED_GLOBAL?: boolean; USE?: boolean; CREATE?: boolean };
+  AGENTS?: { SHARED_GLOBAL?: boolean; USE?: boolean; CREATE?: boolean };
+  MEMORIES?: { USE?: boolean; CREATE?: boolean; UPDATE?: boolean; READ?: boolean; OPT_OUT?: boolean };
+  BOOKMARKS?: { USE?: boolean };
+  WEB_SEARCH?: { USE?: boolean };
+  PEOPLE_PICKER?: { VIEW_USERS?: boolean; VIEW_GROUPS?: boolean; VIEW_ROLES?: boolean };
+  MARKETPLACE?: { USE?: boolean };
+  MCP_SERVERS?: { USE?: boolean; CREATE?: boolean; SHARE?: boolean };
+  FILE_SEARCH?: { USE?: boolean };
+  FILE_CITATIONS?: { USE?: boolean };
+  RUN_CODE?: { USE?: boolean };
+  MULTI_CONVO?: { USE?: boolean };
+  TEMPORARY_CHAT?: { USE?: boolean };
+}
+
+interface RoleConfig {
+  name: string;
+  permissions: RolePermissions;
+}
+
+interface Config {
+  roles: RoleConfig[];
+}
+
+// Configuration
+const configPath = join(__dirname, '../config/roles.json');
+const config: Config = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://mongodb:27017/LibreChat';
+const DEFAULT_ADMINS = process.env.LIBRECHAT_DEFAULT_ADMINS || '';
+
+// Mongoose schemas
+const rolePermissionsSchema = new mongoose.Schema({
+  PROMPTS: { SHARED_GLOBAL: Boolean, USE: Boolean, CREATE: Boolean },
+  AGENTS: { SHARED_GLOBAL: Boolean, USE: Boolean, CREATE: Boolean },
+  MEMORIES: { USE: Boolean, CREATE: Boolean, UPDATE: Boolean, READ: Boolean, OPT_OUT: Boolean },
+  BOOKMARKS: { USE: Boolean },
+  WEB_SEARCH: { USE: Boolean },
+  PEOPLE_PICKER: { VIEW_USERS: Boolean, VIEW_GROUPS: Boolean, VIEW_ROLES: Boolean },
+  MARKETPLACE: { USE: Boolean },
+  MCP_SERVERS: { USE: Boolean, CREATE: Boolean, SHARE: Boolean },
+  FILE_SEARCH: { USE: Boolean },
+  FILE_CITATIONS: { USE: Boolean },
+  RUN_CODE: { USE: Boolean },
+  MULTI_CONVO: { USE: Boolean },
+  TEMPORARY_CHAT: { USE: Boolean }
+}, { _id: false });
+
+const roleSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true, uppercase: true },
+  permissions: { type: rolePermissionsSchema, default: {} }
+});
+
+const Role = mongoose.model('Role', roleSchema);
+interface IUser extends mongoose.Document {
+  _id: mongoose.Types.ObjectId;
+  email: string;
+  role: string;
+}
+const User = mongoose.model<IUser>('User', new mongoose.Schema({}, { strict: false }));
+
+async function waitForMongoDB(maxRetries = 30, delayMs = 2000): Promise<void> {
+  console.log('Waiting for MongoDB to be ready...');
+  
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      await mongoose.connect(MONGO_URI, {
+        serverSelectionTimeoutMS: 5000
+      });
+      console.log('✓ Connected to MongoDB');
+      return;
+    } catch (error) {
+      console.log(`  Attempt ${i + 1}/${maxRetries}...`);
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+  
+  throw new Error('MongoDB not available after maximum retries');
+}
+
+export async function initializeRoles(): Promise<void> {
+  try {
+    await waitForMongoDB();
+
+    console.log('Initializing custom roles...');
+
+    // Create/update custom roles from config
+    let rolesProcessed = 0;
+    for (const roleConfig of config.roles) {
+      const roleName = roleConfig.name.toUpperCase();
+      
+      // Skip system roles
+      if (roleName === 'ADMIN' || roleName === 'USER') {
+        console.log(`  ⚠ Skipping system role: ${roleName}`);
+        continue;
+      }
+
+      const existingRole = await Role.findOne({ name: roleName });
+      
+      if (existingRole) {
+        existingRole.permissions = roleConfig.permissions;
+        await existingRole.save();
+        console.log(`  ✓ Updated role: ${roleName}`);
+      } else {
+        await Role.create({
+          name: roleName,
+          permissions: roleConfig.permissions
+        });
+        console.log(`  ✓ Created role: ${roleName}`);
+      }
+      rolesProcessed++;
+    }
+
+    console.log(`✓ Processed ${rolesProcessed} custom role(s)`);
+
+    // Assign admin role to default admins
+    if (DEFAULT_ADMINS) {
+      console.log('Assigning admin roles...');
+      const adminEmails = DEFAULT_ADMINS.split(',')
+        .map(email => email.trim())
+        .filter(Boolean);
+      
+      let adminsAssigned = 0;
+      for (const email of adminEmails) {
+        const user = await User.findOne({ email });
+        
+        if (user) {
+          if (user.role !== 'ADMIN') {
+            await User.updateOne({ email }, { $set: { role: 'ADMIN' } });
+            console.log(`  ✓ Assigned ADMIN to: ${email}`);
+            adminsAssigned++;
+          } else {
+            console.log(`  - Already ADMIN: ${email}`);
+          }
+        } else {
+          console.log(`  ⚠ User not found: ${email} (will be set on first login)`);
+        }
+      }
+      console.log(`✓ Assigned ADMIN role to ${adminsAssigned} user(s)`);
+    } else {
+      console.log('ℹ No default admins configured (LIBRECHAT_DEFAULT_ADMINS)');
+    }
+
+    console.log('✓ Role initialization completed');
+    
+  } catch (error) {
+    console.error('✗ Error during role initialization:', error);
+    throw error;
+  } finally {
+    await mongoose.disconnect();
+  }
+}

--- a/packages/librechat-init/src/init.ts
+++ b/packages/librechat-init/src/init.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env -S node --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings
+import { copyFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { setupPermissions } from './setup-permissions.ts';
+import { initializeRoles } from './init-roles.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const CONFIG_SOURCE = join(__dirname, '../config/librechat.yaml');
+const CONFIG_TARGET = '/app/config/librechat.yaml';
+
+async function main() {
+  console.log('=========================================');
+  console.log('LibreChat Initialization Started');
+  console.log('=========================================\n');
+
+  try {
+    // Task 1: Copy LibreChat config
+    console.log('[1/3] Setting up LibreChat configuration...');
+    if (existsSync(CONFIG_SOURCE)) {
+      copyFileSync(CONFIG_SOURCE, CONFIG_TARGET);
+      console.log('✓ Config copied successfully');
+    } else {
+      throw new Error(`Config file not found: ${CONFIG_SOURCE}`);
+    }
+
+    // Task 2: Setup file permissions
+    console.log('\n[2/3] Setting up file permissions...');
+    await setupPermissions();
+
+    // Task 3: Initialize MongoDB roles
+    console.log('\n[3/3] Initializing MongoDB roles...');
+    await initializeRoles();
+
+    console.log('\n=========================================');
+    console.log('✓ LibreChat Initialization Completed');
+    console.log('=========================================');
+    process.exit(0);
+
+  } catch (error) {
+    console.error('\n✗ Initialization failed:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/librechat-init/src/setup-permissions.ts
+++ b/packages/librechat-init/src/setup-permissions.ts
@@ -1,0 +1,38 @@
+import { execSync } from 'child_process';
+
+const PATHS = [
+  '/logs',
+  '/images',
+  '/uploads',
+  '/mongo_data',
+  '/mongo_configdb',
+  '/meili_data'
+];
+
+export async function setupPermissions(): Promise<void> {
+  const uid = parseInt(process.env.UID || '1000');
+  const gid = parseInt(process.env.GID || '1000');
+  
+  // Check if running as root
+  const isRoot = process.getuid?.() === 0;
+  
+  if (!isRoot) {
+    console.log('⚠ Not running as root, skipping permissions setup');
+    return;
+  }
+
+  console.log(`Setting permissions for UID:GID ${uid}:${gid}...`);
+
+  for (const path of PATHS) {
+    try {
+      // Use system chown/chmod for recursive operations (more reliable)
+      execSync(`chown -R ${uid}:${gid} ${path} 2>/dev/null || true`);
+      execSync(`chmod -R 775 ${path} 2>/dev/null || true`);
+    } catch (error) {
+      // Non-critical - some paths might not exist yet
+      console.log(`  ⚠ Could not set permissions for ${path}`);
+    }
+  }
+
+  console.log('✓ Permissions configured');
+}

--- a/packages/librechat-init/tsconfig.json
+++ b/packages/librechat-init/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "config/**/*"]
+}

--- a/scripts/setup-env.ts
+++ b/scripts/setup-env.ts
@@ -22,11 +22,6 @@ const PROD_EXAMPLE_FILE = path.join(ROOT_DIR, 'env.prod.example');
 const genSecret = (length: number = 32): string => crypto.randomBytes(length).toString('hex');
 
 /**
- * Generate a random short string for usernames/dbnames
- */
-const genShortId = (prefix: string): string => `${prefix}_${crypto.randomBytes(3).toString('hex')}`;
-
-/**
  * Check if a value contains variable expansions (e.g., ${VAR_NAME})
  */
 const containsVariableExpansion = (value: string): boolean => {
@@ -93,6 +88,7 @@ const PROMPTS: Record<string, PromptConfig> = {
     // Email (Production only)
     'EMAIL_PASSWORD': { message: 'SendGrid API Key (for email verification):', type: 'password', prodOnly: true },
     'EMAIL_FROM': { message: 'Email From Address (e.g., noreply@faktenforum.org):', type: 'input', prodOnly: true },
+    'LIBRECHAT_DEFAULT_ADMINS': { message: 'Default LibreChat Admin Emails (comma-separated, optional):', type: 'input' },
 };
 
 /**


### PR DESCRIPTION
## Problem

Docker-compose has 600+ lines of hardcoded scripts. Previous plans used shell scripts, but we can make this much cleaner with TypeScript.

## Solution

One TypeScript-based init service that:

1. Copies LibreChat YAML config (no generation needed)
2. Sets up file permissions
3. Initializes MongoDB roles

All in TypeScript, executed directly with Node.js like [`scripts/setup-env.ts`](scripts/setup-env.ts).

## Architecture

```mermaid
graph TD
    subgraph librechatInit [librechat-init Package]
        config[config/librechat.yaml]
        roles[config/roles.json]
        init[src/init.ts]
        perms[src/setup-permissions.ts]
        dbRoles[src/init-roles.ts]
        
        init -->|1 copy config| config
        init -->|2 call| perms
        init -->|3 call| dbRoles
        dbRoles -->|uses| roles
    end
    
    mongodb[MongoDB]
    api[LibreChat API]
    
    mongodb -->|healthy| librechatInit
    librechatInit -->|completed| api
```

[Ticket](https://correctivdigital.openproject.com/projects/ff-checkbot/work_packages/1964)
