### PR TITLE
refactor: decouple external Faktenforum Search, drop dev/search submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,9 +51,6 @@
 	path = dev/docs-mcp-server
 	url = git@github.com:faktenforum/docs-mcp-server.git
 	branch = main
-[submodule "dev/search"]
-	path = dev/search
-	url = git@github.com:faktenforum/search.git
 [submodule "workspaces/document-creator"]
 	path = workspaces/document-creator
 	url = git@github.com:faktenforum/workspace-document-creator.git

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ They are baked into the init image and written into the config volume at startup
 - **[YTPTube Cleanup](YTPTUBE_CLEANUP.md)** - Where archive and downloads live; how to clean for fresh tests
 - **[MCP YouTube Transcript](MCP_YOUTUBE_TRANSCRIPT.md)** - YouTube Transcript MCP (video URL → transcript via youtube-transcript-api)
 - **[MCP Grounded Docs](MCP_DOCS.md)** - Grounded Docs MCP (documentation index; optional embeddings)
-- **[Faktenforum Search](../dev/search/README.md)** - External fact-check search (MCP); configure URL and API key in env
+- **[Faktenforum Search](SERVICES.md)** - Optional external fact-check search (MCP), hosted as part of Faktenforum; opt-in via `SEARCH_MCP_URL`
 - **[MCP Chefkoch](MCP_CHEFKOCH.md)** – Recipes from chefkoch.de (get_recipe, search_recipes, get_random_recipe, get_daily_recipes). Internal only.
 - **[MCP Linux](MCP_LINUX.md)** – Per-user isolated Linux terminal with persistent git workspaces. Tools: execute_command, workspace management, account tools. Internal only.
 - **[GitHub Machine User](GITHUB_MACHINE_USER.md)** – Shared GitHub identity for MCP Linux (SSH) and GitHub MCP (PAT).

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -71,7 +71,7 @@ Application servers, databases, and infrastructure (excluding MCP servers).
 
 **RAG API** — Retrieval-Augmented Generation service for document search. Network: `app-net`. Access: LibreChat API only.
 
-**Faktenforum Search (external)** — LibreChat connects to an **external** Faktenforum Search instance via MCP. No Search services run in this stack. Configure `SEARCH_MCP_URL`, `SEARCH_MCP_API_KEY`, and `SEARCH_MCP_DOMAIN` in env. To run or deploy Search, see [Search docs](../dev/search/README.md).
+**Faktenforum Search (external, optional)** — LibreChat optionally connects to an **external** Faktenforum Search instance via MCP. Search is no longer deployed by this stack; it is hosted as part of Faktenforum (prod `https://api.faktenforum.org/search/`, dev `https://dev-api.faktenforum.org/search/`). The integration is opt-in: it activates only when `SEARCH_MCP_URL` is set. Leave it empty to disable - the Search MCP server and the Faktencheck agent are then omitted at init time. Configure `SEARCH_MCP_URL`, `SEARCH_MCP_API_KEY`, and `SEARCH_MCP_DOMAIN` in env (e.g. `SEARCH_MCP_URL=https://dev-api.faktenforum.org/search/mcp`, `SEARCH_MCP_DOMAIN=dev-api.faktenforum.org`).
 
 **YTPTube** — yt-dlp Web UI; queues downloads. MCP YTPTube uses it for audio/transcripts. Network: `app-net` + `traefik-net` (prod/dev: download-only router `PathPrefix(/api/download)` at `https://ytptube.{DOMAIN}/api/download/*`); local/local-dev: full host `http://ytptube.{DOMAIN}`. Image: `ghcr.io/arabcoders/ytptube:latest`
 

--- a/env.dev.example
+++ b/env.dev.example
@@ -194,8 +194,12 @@ MCP_GITHUB_PAT=
 MCP_MAPBOX_ACCESS_TOKEN=
 
 # ─── Faktenforum Search (external MCP) ────────────────────────────────────────
-# LibreChat connects to an external Faktenforum Search instance. No Search services run in this stack.
-SEARCH_MCP_URL=https://search.example.com/mcp
+# Optional. LibreChat connects to an external Faktenforum Search instance via MCP.
+# Search is no longer deployed by this stack; it is hosted as part of Faktenforum.
+# Leave empty to disable - the Search MCP server and the Faktencheck agent are then
+# omitted at init time. To enable, set the URL + API key plus the domain (MCP allowlist).
+#   dev instance: SEARCH_MCP_URL=https://dev-api.faktenforum.org/search/mcp  SEARCH_MCP_DOMAIN=dev-api.faktenforum.org
+SEARCH_MCP_URL=
 SEARCH_MCP_API_KEY=
 SEARCH_API_KEY=
-SEARCH_MCP_DOMAIN=search.example.com
+SEARCH_MCP_DOMAIN=

--- a/env.local.example
+++ b/env.local.example
@@ -275,13 +275,14 @@ MCP_GITHUB_PAT=
 MCP_MAPBOX_ACCESS_TOKEN=
 
 # ─── Faktenforum Search (external MCP) ────────────────────────────────────────
-# LibreChat connects to an external Faktenforum Search instance. No Search services run in this stack.
-# Set URL and API key to match the external Search; set domain for LibreChat SSRF allowlist.
-#
-# Local without Traefik (Search runs as separate stack, port 3020 on host):
-#   URL/DOMAIN as below. On Linux, ensure host.docker.internal resolves (Docker 20.10+ or add extra_hosts in compose).
-# With Traefik (Search behind same Traefik): use http://search.localhost/mcp and search.localhost.
-SEARCH_MCP_URL=http://host.docker.internal:3020/mcp
+# Optional. LibreChat connects to an external Faktenforum Search instance via MCP.
+# Search is no longer deployed by this stack; it is hosted as part of Faktenforum.
+# Leave empty to disable - the Search MCP server and the Faktencheck agent are then
+# omitted at init time. To enable, set the URL + API key plus the domain (used for
+# LibreChat's MCP SSRF allowlist):
+#   prod: SEARCH_MCP_URL=https://api.faktenforum.org/search/mcp      SEARCH_MCP_DOMAIN=api.faktenforum.org
+#   dev:  SEARCH_MCP_URL=https://dev-api.faktenforum.org/search/mcp  SEARCH_MCP_DOMAIN=dev-api.faktenforum.org
+SEARCH_MCP_URL=
 SEARCH_MCP_API_KEY=
 SEARCH_API_KEY=
-SEARCH_MCP_DOMAIN=host.docker.internal
+SEARCH_MCP_DOMAIN=

--- a/env.prod.example
+++ b/env.prod.example
@@ -188,8 +188,12 @@ MCP_GITHUB_PAT=
 MCP_MAPBOX_ACCESS_TOKEN=
 
 # ─── Faktenforum Search (external MCP) ────────────────────────────────────────
-# LibreChat connects to an external Faktenforum Search instance. No Search services run in this stack.
-SEARCH_MCP_URL=https://search.example.com/mcp
+# Optional. LibreChat connects to an external Faktenforum Search instance via MCP.
+# Search is no longer deployed by this stack; it is hosted as part of Faktenforum.
+# Leave empty to disable - the Search MCP server and the Faktencheck agent are then
+# omitted at init time. To enable, set the URL + API key plus the domain (MCP allowlist).
+#   prod instance: SEARCH_MCP_URL=https://api.faktenforum.org/search/mcp  SEARCH_MCP_DOMAIN=api.faktenforum.org
+SEARCH_MCP_URL=
 SEARCH_MCP_API_KEY=
 SEARCH_API_KEY=
-SEARCH_MCP_DOMAIN=search.example.com
+SEARCH_MCP_DOMAIN=

--- a/packages/librechat-init/config/agents.yaml
+++ b/packages/librechat-init/config/agents.yaml
@@ -12,8 +12,6 @@ agents:
     tools:
       - web_search
       - file_search
-    mcpServers:
-      - search
     category: general
     conversation_starters:
       - Research current information on climate change

--- a/packages/librechat-init/src/init-agents.ts
+++ b/packages/librechat-init/src/init-agents.ts
@@ -25,6 +25,7 @@ import {
   MCP_DELIMITER,
   MCP_SERVER,
   MCP_ALL,
+  SEARCH_MCP_SERVER_NAME,
   DEFAULT_API_URL,
 } from './utils/constants.ts';
 import {
@@ -133,6 +134,43 @@ function buildToolsArray(agentConfig: AgentConfig): string[] {
   }
 
   return tools;
+}
+
+/**
+ * Gates agents on the optional Faktenforum Search integration. When SEARCH_MCP_URL is
+ * not set, init.ts omits the Search MCP server, so agents must not reference it: strip
+ * the "search" server (and its tools) from every agent, and drop agents that depend on
+ * Search exclusively (the Faktencheck agent has no other tools).
+ */
+function gateOptionalSearchAgents(agents: AgentConfig[]): AgentConfig[] {
+  if (process.env.SEARCH_MCP_URL?.trim()) {
+    return agents;
+  }
+
+  const searchToolSuffix = `${MCP_DELIMITER}${SEARCH_MCP_SERVER_NAME}`;
+  const kept: AgentConfig[] = [];
+
+  for (const agent of agents) {
+    if (!agent.mcpServers?.includes(SEARCH_MCP_SERVER_NAME)) {
+      kept.push(agent);
+      continue;
+    }
+
+    const mcpServers = agent.mcpServers.filter((s) => s !== SEARCH_MCP_SERVER_NAME);
+    const mcpTools = (agent.mcpTools || []).filter((t) => !t.endsWith(searchToolSuffix));
+    const hasOtherCapabilities =
+      mcpServers.length > 0 || mcpTools.length > 0 || (agent.tools?.length ?? 0) > 0;
+
+    if (!hasOtherCapabilities) {
+      console.log(`  ✓ Agent "${agent.name}" omitted (depends on Search; SEARCH_MCP_URL not set)`);
+      continue;
+    }
+
+    console.log(`  ✓ Stripped Search MCP from agent "${agent.name}" (SEARCH_MCP_URL not set)`);
+    kept.push({ ...agent, mcpServers, mcpTools });
+  }
+
+  return kept;
 }
 
 /**
@@ -524,7 +562,8 @@ function resolveAgentReferences(
  */
 export async function initializeAgents(): Promise<void> {
   try {
-    const { agents: allAgents, publicCount, privateCount } = loadAgentConfigs();
+    const { agents: loadedAgents, publicCount, privateCount } = loadAgentConfigs();
+    const allAgents = gateOptionalSearchAgents(loadedAgents);
 
     if (allAgents.length === 0) {
       console.log('ℹ No agents configured - skipping agent initialization');

--- a/packages/librechat-init/src/init.ts
+++ b/packages/librechat-init/src/init.ts
@@ -13,6 +13,8 @@ import {
   ASSETS_DIR,
   IMAGES_DIR,
   INIT_TIME_ENV_VARS,
+  SEARCH_MCP_SERVER_NAME,
+  SEARCH_DEPENDENT_AGENT_ID,
 } from './utils/constants.ts';
 import {
   loadAgentIdMap,
@@ -96,15 +98,31 @@ async function main() {
         console.log(`✓ Merged override: librechat.${libreachEnv}.yaml`);
       }
 
-      // Omit Search MCP server when URL is not set (avoids "Invalid URL" in LibreChat)
+      // Optional Faktenforum Search: when SEARCH_MCP_URL is not set, omit the Search MCP
+      // server (avoids "Invalid URL" in LibreChat) and the Faktencheck model spec. The
+      // matching agent is dropped in init-agents.ts.
       const searchMcpUrl = process.env.SEARCH_MCP_URL?.trim();
       const mcpServers = configObj?.mcpServers as Record<string, { url?: string }> | undefined;
-      if (mcpServers && 'search' in mcpServers) {
+      if (mcpServers && SEARCH_MCP_SERVER_NAME in mcpServers) {
         if (!searchMcpUrl) {
-          delete mcpServers['search'];
+          delete mcpServers[SEARCH_MCP_SERVER_NAME];
           console.log('✓ Search MCP omitted (SEARCH_MCP_URL not set)');
         } else {
-          mcpServers['search'].url = searchMcpUrl;
+          mcpServers[SEARCH_MCP_SERVER_NAME].url = searchMcpUrl;
+        }
+      }
+      if (!searchMcpUrl) {
+        const modelSpecs = configObj?.modelSpecs as
+          | { list?: Array<{ preset?: { agent_id?: string } }> }
+          | undefined;
+        if (Array.isArray(modelSpecs?.list)) {
+          const before = modelSpecs.list.length;
+          modelSpecs.list = modelSpecs.list.filter(
+            (spec) => spec?.preset?.agent_id !== SEARCH_DEPENDENT_AGENT_ID
+          );
+          if (modelSpecs.list.length < before) {
+            console.log('✓ Faktencheck model spec omitted (SEARCH_MCP_URL not set)');
+          }
         }
       }
 

--- a/packages/librechat-init/src/utils/constants.ts
+++ b/packages/librechat-init/src/utils/constants.ts
@@ -52,6 +52,12 @@ export const MCP_SERVER = 'sys__server__sys';
 /** Marker for "all tools" from an MCP server. */
 export const MCP_ALL = 'sys__all__sys';
 
+/** Optional Faktenforum Search integration (gated on SEARCH_MCP_URL being set). */
+export const SEARCH_MCP_SERVER_NAME = 'search';
+
+/** Agent that depends entirely on the Search MCP server; omitted when Search is disabled. */
+export const SEARCH_DEPENDENT_AGENT_ID = 'shared-agent-faktencheck';
+
 // ============================================================================
 // Access Control
 // ============================================================================

--- a/scripts/setup-env.ts
+++ b/scripts/setup-env.ts
@@ -235,10 +235,10 @@ const PROMPTS: Record<string, PromptConfig> = {
     'MCP_LINUX_GIT_SSH_KEY': { message: 'MCP Linux GitHub SSH Key base64 (optional; for git access):', type: 'password', defaultGen: () => '' },
 
     // Faktenforum Search (external MCP; optional)
-    'SEARCH_MCP_URL': { message: 'Search MCP URL (optional; e.g. http://search.localhost/mcp):', type: 'input', defaultGen: () => '' },
+    'SEARCH_MCP_URL': { message: 'Search MCP URL (optional; empty disables; e.g. https://dev-api.faktenforum.org/search/mcp):', type: 'input', defaultGen: () => '' },
     'SEARCH_MCP_API_KEY': { message: 'Search MCP API key (optional; must match external Search):', type: 'password', defaultGen: () => '' },
     'SEARCH_API_KEY': { message: 'Search REST API key (optional; must match external Search):', type: 'password', defaultGen: () => '' },
-    'SEARCH_MCP_DOMAIN': { message: 'Search MCP domain for allowlist (optional; e.g. search.localhost):', type: 'input', defaultGen: () => '' },
+    'SEARCH_MCP_DOMAIN': { message: 'Search MCP domain for allowlist (optional; e.g. dev-api.faktenforum.org):', type: 'input', defaultGen: () => '' },
 
     // MCP Linux - Code index (semantic code search; optional)
     'CODE_INDEX_EMBEDDING_API_KEY': { message: 'Code index embedding API key (optional; OpenRouter or Scaleway for semantic code search):', type: 'password', defaultGen: () => '' },


### PR DESCRIPTION
## What

Makes the Faktenforum Search integration an optional, external-only connection and removes the `dev/search` submodule.

Search is no longer deployed by this stack - it is hosted as part of Faktenforum (prod `https://api.faktenforum.org/search/`, dev `https://dev-api.faktenforum.org/search/`). The MCP integration stays but is opt-in: it activates only when `SEARCH_MCP_URL` is set.

## Changes

- Remove the `dev/search` submodule (`.gitmodules` + tree)
- Env examples: `SEARCH_*` empty by default, real prod/dev instances documented as comments
- `init.ts`: when `SEARCH_MCP_URL` is unset, omit the Search MCP server, its allowlist domain (already), and now also the Faktencheck model spec
- `init-agents.ts`: gate search-dependent agents - strip the `search` MCP server/tools and drop agents that depend on it exclusively (the Faktencheck agent)
- `agents.yaml`: remove the vestigial `search` reference from the public Research agent (it used no search tools)
- Docs: describe Search as optional/external, fix the dead submodule link

## Why

`dev/search` is no longer a standalone project. Keeping only the optional connection lets the rest of the stack go open-source without bundling or hard-depending on Search.

## Testing

- `tsc --noEmit` green for librechat-init
- Config transform verified both ways: Search disabled -> Search MCP + Faktencheck spec removed (39 specs); enabled -> both present with correct URL (40 specs)
- Agent gating verified against the real `agents.yaml`: exactly 1 agent (Faktencheck) dropped when Search is disabled, none wrongly stripped