### PR TITLE
chore(docs-mcp-server): drop redundant fork customization, track upstream 2.4.2

### DIFF
--- a/docs/MCP_DOCS.md
+++ b/docs/MCP_DOCS.md
@@ -1,6 +1,6 @@
 # MCP Grounded Docs
 
-[Grounded Docs](https://github.com/arabold/docs-mcp-server) MCP server: documentation index for AI (websites, GitHub, npm, local files). We use the [Faktenforum fork](https://github.com/faktenforum/docs-mcp-server) at `dev/docs-mcp-server` and build the image from the submodule (Pattern 3). The fork adds a configurable embedding dimension so Scaleway (3584) and OpenRouter (1536) work without DB mismatch.
+[Grounded Docs](https://github.com/arabold/docs-mcp-server) MCP server: documentation index for AI (websites, GitHub, npm, local files). We track upstream at `dev/docs-mcp-server` (via the `faktenforum/docs-mcp-server` mirror) and build the image from the submodule (Pattern 3). Upstream now natively supports a configurable embedding dimension (`DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION`) so Scaleway (3584) and OpenRouter (1536) work without DB mismatch.
 
 ## Configuration
 

--- a/scripts/submodules-upstream.yaml
+++ b/scripts/submodules-upstream.yaml
@@ -64,7 +64,7 @@ submodules:
     upstream_branch: main
     fork_branch: main
     upstream_tracking_branch: upstream
-    description: "Grounded Docs MCP server fork (configurable embedding dimension)"
+    description: "Grounded Docs MCP server (fork mirrors upstream; configurable embedding dimension is now upstream-native)"
 
   - path: dev/agents
     fork_url: git@github.com:faktenforum/agents.git


### PR DESCRIPTION
## What

The `dev/docs-mcp-server` fork's only customization (configurable embedding dimension) is now provided natively by upstream, so the fork is reset to upstream `2.4.2` and tracked as a clean mirror.

## Why

Upstream docs-mcp-server 2.4.2:
- reads the **same** env var our stack already sets: `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` (`src/store/embeddings/EmbeddingFactory.ts`)
- adds `embeddings.vectorDimension` config + a `FixedDimensionEmbeddings` class with tests

Our custom migration also collided with upstream's (`012-drop-documents-vec-for-runtime.sql` vs upstream `012-add-source-content-type.sql`). The customization is redundant and conflicting, so it is dropped.

## Changes

- `dev/docs-mcp-server` pointer -> upstream `2.4.2` (`0091ab8`); the `faktenforum/docs-mcp-server` fork main was reset to upstream and force-pushed (now a clean mirror)
- docs + submodule registry description updated to reflect upstream-native dimension support

## Testing

- `mcp-docs` image builds cleanly from the submodule (local-dev)
- Stack config unchanged: we already set `MCP_DOCS_EMBEDDINGS_VECTOR_DIMENSION=3584` (Scaleway) / omit for OpenRouter

## Deploy note

Existing prod/dev docs index DBs recorded our old migration `012`; after deploy they may need a reindex (the index is rebuildable, no user data).