### PR TITLE
fix(prod,dev): mount the agents fork so its customizations reach prod/dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,12 @@ services:
     container_name: ${STACK_NAME:-prod}-librechat
     # Use pre-built image from registry (built by GitHub Actions)
     image: ghcr.io/faktenforum/librechat:dev
+    # Override the image's npm @librechat/agents with our built fork (vision gating,
+    # custom reranker). PREREQUISITE on the deploy host: submodules cloned recursively
+    # AND the fork built (`npm run build:dev`). An empty/unbuilt dev/agents makes the
+    # package empty and LibreChat will fail to start. See docs/PORTAINER-CONFIG.md.
+    volumes:
+      - ./dev/agents:/app/node_modules/@librechat/agents
     depends_on:
       librechat-init:
         condition: service_completed_successfully

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -42,6 +42,14 @@ services:
     container_name: ${STACK_NAME:-prod}-librechat
     # Use pre-built image from registry (built by GitHub Actions)
     image: ghcr.io/faktenforum/librechat:latest
+    # Override the image's npm @librechat/agents with our built fork (vision gating,
+    # custom reranker). The registry image ships upstream @librechat/agents; this mount
+    # makes our customizations effective in prod.
+    # PREREQUISITE on the deploy host: submodules cloned recursively AND the fork built
+    # (`npm run build:dev`). An empty/unbuilt dev/agents makes the package empty and
+    # LibreChat will fail to start. See docs/PORTAINER-CONFIG.md.
+    volumes:
+      - ./dev/agents:/app/node_modules/@librechat/agents
     depends_on:
       librechat-init:
         condition: service_completed_successfully

--- a/docs/PORTAINER-CONFIG.md
+++ b/docs/PORTAINER-CONFIG.md
@@ -72,6 +72,15 @@ Enable automatic stack updates from GitHub using webhooks for immediate deployme
 
 When changes are pushed to the repository, Portainer automatically pulls the latest code and updates the stack. All volumes are preserved (data is not lost).
 
+### Agents fork (prod/dev)
+
+`docker-compose.prod.yml` and `docker-compose.dev.yml` mount our `@librechat/agents` fork over the registry image's npm copy (`./dev/agents:/app/node_modules/@librechat/agents`) so the fork's customizations (vision gating, custom reranker) take effect. Two host prerequisites, or LibreChat will fail to start with an empty `@librechat/agents`:
+
+1. Clone submodules recursively (Portainer: enable recursive/submodule clone for the stack repo).
+2. Build the fork before deploy: `npm run build:dev` (runs `build-dev-submodules.sh`, which builds `dev/agents`). The mount needs `dev/agents/dist`.
+
+Alternative (more robust for the registry-image model): bake the built fork into the librechat image in CI instead of mounting it. Tracked as a follow-up.
+
 ## Data Safety
 
 **⚠️ Important:**


### PR DESCRIPTION
## What
prod/dev ran the registry `librechat` image with npm `@librechat/agents@3.2.38`, so our agents fork (vision gating, custom reranker) had **no effect in prod/dev** - only `local-dev` mounted it. This mounts `./dev/agents` over `/app/node_modules/@librechat/agents` in `docker-compose.prod.yml` + `docker-compose.dev.yml`, mirroring local-dev.

## ⚠️ Deploy prerequisite (important)
The mount overrides the package with host source, so the deploy host must:
1. Clone submodules **recursively** (Portainer: enable submodule clone).
2. **Build** the fork before deploy: `npm run build:dev` (needs `dev/agents/dist`).

If `dev/agents` is empty/unbuilt, `@librechat/agents` is empty and LibreChat won't start. Documented in `docs/PORTAINER-CONFIG.md`.

## Alternative (follow-up)
For the registry-image model, baking the built fork into the CI image is more robust than a runtime bind mount. Noted as a follow-up — happy to implement if preferred.

## Testing
`docker compose -f docker-compose.prod.yml --env-file .env.prod config` and the dev equivalent parse cleanly; the mount resolves to `dev/agents`.