### PR TITLE
fix(podman): support stateful services under rootless podman

### DIFF
--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -7,13 +7,22 @@
 # What this adds over the Docker setup (which is unchanged):
 #   - Traefik reaches the container runtime over Podman's Docker-API-compatible socket.
 #     Set CONTAINER_SOCKET=/run/user/$UID/podman/podman.sock (the npm scripts do this).
-#   - security_opt label=disable lets the (SELinux-confined) Traefik container read that
-#     socket on SELinux hosts (Fedora etc.); without it the docker provider gets
-#     "permission denied while trying to connect to the docker API".
+#   - security_opt label=disable lets SELinux-confined containers (Traefik's socket
+#     mount, Meilisearch's bind-mounted data dir) work on SELinux hosts (Fedora etc.);
+#     without it they get "permission denied" (docker API / os error 13).
+#   - mongodb runs as the image-default uid 999. The chown-init that aligns the named
+#     volume to uid 1000 under Docker does not take effect under rootless Podman (the
+#     volume keeps the image's 999 ownership), so forcing user 1000 makes mongod fail
+#     with "Permission denied ... /data/db/journal". Running as 999 matches the volume.
 #
 # Rootless ports: binding 80/443 rootless needs `net.ipv4.ip_unprivileged_port_start=80`
 # (sysctl). Otherwise set TRAEFIK_HTTP_PORT/TRAEFIK_HTTPS_PORT to >=1024. See docs/PODMAN.md.
 services:
   traefik:
+    security_opt:
+      - label=disable
+  mongodb:
+    user: "999:999"
+  meilisearch:
     security_opt:
       - label=disable

--- a/docs/PODMAN.md
+++ b/docs/PODMAN.md
@@ -30,10 +30,11 @@ CONTAINER_SOCKET=/run/user/$(id -u)/podman/podman.sock \
 
 ## What differs from Docker
 
-Two things, both handled by the override + env, so the Docker setup is untouched:
+All handled by the override + env, so the Docker setup is untouched:
 
 - **Traefik socket.** Traefik's docker provider reads the runtime socket. `CONTAINER_SOCKET` (default `/var/run/docker.sock`) points it at the Podman socket instead. Set in `docker-compose.traefik.yml`.
-- **SELinux.** On SELinux hosts (Fedora etc.) the confined Traefik container cannot read the mounted socket and the provider fails with `permission denied while trying to connect to the docker API`. `docker-compose.podman.yml` adds `security_opt: label=disable` to Traefik to allow it.
+- **SELinux.** On SELinux hosts (Fedora etc.) confined containers cannot read host-mounted paths and fail with `permission denied` (`os error 13` / docker API). `docker-compose.podman.yml` adds `security_opt: label=disable` to the affected services - Traefik (socket mount) and Meilisearch (bind-mounted `meili_data` dir).
+- **MongoDB volume ownership.** Under Docker a chown-init aligns the `mongodata` named volume to uid 1000 and mongod runs as 1000. That chown does not take effect under rootless Podman - the volume keeps the mongo image's default uid 999 - so forcing uid 1000 makes mongod fail with `Permission denied ... /data/db/journal`. The override runs mongodb as `999:999` to match the volume. Other stateful services with named volumes may need the same treatment (see Status).
 
 `host.docker.internal:host-gateway` (used by Firecrawl) is supported natively by Podman 5.x. The `traefik.docker.network` labels work because the Podman socket presents networks over the Docker API.
 
@@ -53,10 +54,22 @@ Rootless Podman cannot bind ports below 1024 by default. Two options:
 
 ## Status
 
-Validated: the Traefik path under rootless Podman on Fedora (SELinux enforcing) - the docker provider connects over the Podman socket, discovers labeled services, and routes (`maildev.localhost` returns 200). The compose files parse and the network/volume model works. A full multi-service run (MongoDB, Meilisearch, LibreChat, the Firecrawl group, MCP servers) has not been exhaustively exercised under Podman yet; if a service hits an SELinux denial on a bind-mounted path, add `:z` to that mount or `security_opt: label=disable` to that service in `docker-compose.podman.yml`.
+Validated under rootless Podman on Fedora (SELinux enforcing):
+
+- **Traefik** - the docker provider connects over the Podman socket, discovers labeled services, and routes (`maildev.localhost` returns 200).
+- **MongoDB** - healthy with the `999:999` override (listens on 27017, `mongosh ping` returns 1). Fails without it (see above).
+- **Meilisearch** - listens on 7700 with the `label=disable` override. Fails without it (bind-mount SELinux denial).
+- **An MCP server** (`mcp-calculator`, our ghcr image) - healthy on `app-net`.
+
+Not yet exercised wholesale (the heavy services - the locally-built LibreChat app, the Firecrawl group, `rag_api`, `vectordb`, `openwebui`): a full bring-up was skipped to avoid resource contention with other live stacks on the dev host, not because of a known issue. When running them, watch for the same two failure classes:
+
+- Bind-mounted path → SELinux denial → add `security_opt: label=disable` to that service in `docker-compose.podman.yml` (or `:z` on the specific mount).
+- Named volume whose Docker chown-init targets uid 1000 → run the service as the image-default uid in the override (as done for mongodb). Candidates: `nuq-postgres` / `vectordb` (postgres data), `rabbitmq`, `firecrawl_pgdata`.
 
 ## Troubleshooting
 
 - `permission denied ... docker API at unix:///var/run/docker.sock` - SELinux. Use the npm scripts / the `docker-compose.podman.yml` override (adds `label=disable`).
 - `rootlessport cannot expose privileged port 80` - raise `ip_unprivileged_port_start` or set `TRAEFIK_HTTP_PORT`/`TRAEFIK_HTTPS_PORT` (see above).
+- mongod `Permission denied ... /data/db/journal` (exit 100) - named-volume uid mismatch under rootless Podman; the override runs mongodb as `999:999`. A stale `mongodata` volume from an earlier run can still carry the wrong owner - `podman volume rm ai-chat-interface_mongodata` and bring it up again.
+- Meilisearch `Permission denied (os error 13)` - SELinux on the `meili_data` bind mount; the override adds `label=disable`.
 - Socket missing - `systemctl --user start podman.socket`.


### PR DESCRIPTION
## What

Makes `mongodb` and `meilisearch` start under rootless Podman. Both changes live only in `docker-compose.podman.yml`, so the Docker setup is untouched.

- **meilisearch**: SELinux denied access to its bind-mounted `meili_data` dir (`os error 13`). Added `security_opt: label=disable`, same as traefik.
- **mongodb**: the Docker chown-init that aligns the `mongodata` named volume to uid 1000 does not take effect under rootless Podman - the volume keeps the mongo image's default uid 999, so the forced `user: 1000` made mongod fail creating `/data/db/journal`. Run mongodb as `999:999` to match the volume.

## Why

The previous podman override only handled traefik's socket. The doc flagged that a full multi-service run was unvalidated; bringing up the stateful services surfaced these two rootless-specific failures.

## Validated

Fedora, SELinux enforcing, rootless Podman 5.8.2 (`podman compose`):

- mongodb healthy, `mongosh ping` returns 1
- meilisearch listening on 7700
- mcp-calculator (our ghcr image) healthy on `app-net`

The heavy services (locally-built LibreChat app, Firecrawl group, rag_api, vectordb, openwebui) were not run wholesale to avoid resource contention with other live stacks on the dev host. `docs/PODMAN.md` documents the diagnosis and the two failure classes to watch for there (likely postgres/rabbitmq named volumes).

## Docs

`docs/PODMAN.md` updated: What-differs, Status, Troubleshooting.