### PR TITLE
docs: refresh upstream PR references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ They are baked into the init image and written into the config volume at startup
 - **[Agent Firecrawl Tools](AGENT_FIRECRAWL_TOOLS.md)** - Firecrawl MCP tool guide
 ## WIP (Work in Progress)
 
-- **[WIP Documentation](wip/README.md)** - YTPTube production, vision architecture, agent token metadata. Vision re-enabled as **experimental/WIP** (`feat/vision`); draft PRs [LibreChat #11501](https://github.com/danny-avila/LibreChat/pull/11501), [agents #48](https://github.com/danny-avila/agents/pull/48)
+- **[WIP Documentation](wip/README.md)** - YTPTube production, vision architecture, agent token metadata. Vision re-enabled as **experimental/WIP** (merged into fork `main`); upstream re-attempts [agents #257](https://github.com/danny-avila/agents/pull/257), [LibreChat #13860](https://github.com/danny-avila/LibreChat/pull/13860)
 - **[TODO](TODO.md)** - Current tasks and improvements
 - **[PR: LibreChat testing](wip/PR-feat-librechat-testing.md)** - PR text draft for feat/librechat-testing
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -52,7 +52,7 @@
 
 - [x] Fix vision model detection for "Upload to AI Provider" option
   - LibreChat discussion [#11333](https://github.com/danny-avila/LibreChat/discussions/11333)
-  - Fixed by: [LibreChat PR #11501](https://github.com/danny-avila/LibreChat/pull/11501) (vision capability flag to modelSpecs)
+  - Handled in our fork; clean upstream re-attempt: [LibreChat #13860](https://github.com/danny-avila/LibreChat/pull/13860) + [agents #257](https://github.com/danny-avila/agents/pull/257) (see [Upstream Contributions](#upstream-contributions))
 - [ ] Add multilingual support for custom titles, labels, and descriptions
   - LibreChat discussion [#7666](https://github.com/danny-avila/LibreChat/discussions/7666) - multilingual support for user-defined content (model specs, MCP servers, interface config, agents)
   - Related: [#10183](https://github.com/danny-avila/LibreChat/issues/10183) (model fields)
@@ -87,7 +87,7 @@
 
 - [x] Fix MCP image generation tools sending artifacts to non-vision models
   - LibreChat issue [#11413](https://github.com/danny-avila/LibreChat/issues/11413)
-  - Fixed by: [LibreChat PR #11504](https://github.com/danny-avila/LibreChat/pull/11504) (vision toggle for agents) and [agents PR #48](https://github.com/danny-avila/agents/pull/48) (filter base64 image artifacts)
+  - Handled in our fork (vision feature); clean upstream re-attempts: [agents #257](https://github.com/danny-avila/agents/pull/257) + [LibreChat #13860](https://github.com/danny-avila/LibreChat/pull/13860) (see [Upstream Contributions](#upstream-contributions))
 - [ ] Reduce SSE stream disconnection error logs
   - Known issue: `streamable-http` MCP servers use stateless HTTP POST while LibreChat's `StreamableHTTPClientTransport` attempts SSE streams, causing "Bad Request" errors. Servers function correctly. Log rotation configured.
   - Related: [LibreChat Discussion #11230](https://github.com/danny-avila/LibreChat/discussions/11230)
@@ -125,11 +125,11 @@
 
 ### danny-avila/LibreChat
 
-Status verified and customizations decided during the 2026-06 upstream sync (forks merged up to upstream/main).
+Status verified and customizations decided during the 2026-06 upstream sync (forks merged up to upstream/main); PR statuses refreshed 2026-06-20.
 
 | Status | Branch | PR | Description / sync decision |
 |--------|--------|----|-------------|
-| Closed (rejected) | `feat/vision` | [#11501](https://github.com/danny-avila/LibreChat/pull/11501) | Vision capability flag for modelSpecs. **Kept as fork divergence** — load-bearing (non-vision Scaleway/OpenRouter models error on image input) and upstream has no agent-vision equivalent. Vision capability type made optional. |
+| Open (draft) | `feat/vision-capability` | [#13860](https://github.com/danny-avila/LibreChat/pull/13860) | Optional `vision` flag on the OpenAI LLM config, forwarded onto the chat-client options so image content is stripped for non-vision models. **Clean minimal re-attempt** off upstream/main; depends on [agents#257](https://github.com/danny-avila/agents/pull/257). Pairs with the load-bearing fork vision feature (non-vision Scaleway/OpenRouter models error on image input). |
 | Open | `fix/mcp-parser` | [#12103](https://github.com/danny-avila/LibreChat/pull/12103) | Auto-detect OpenAI-compatible custom endpoints in formatToolContent. **Kept** (Scaleway depends on it); merged with upstream's new MCP image-size validation. |
 | Open | `feat/stt` | [#11528](https://github.com/danny-avila/LibreChat/pull/11528) | Prefer ogg/wav in external STT recording. Not affected by the sync. |
 | Open | — | depends on [#10574](https://github.com/danny-avila/LibreChat/pull/10574) | Replace Jina reranker with RAG API reranker (`rerankerType: "simple"`); not our PR. |
@@ -139,9 +139,7 @@ Status verified and customizations decided during the 2026-06 upstream sync (for
 
 | Status | Branch | PR | Description / sync decision |
 |--------|--------|----|-------------|
-| Open | — | [#48](https://github.com/danny-avila/agents/pull/48) | Filter base64 image artifacts based on agent vision capability. **Kept** — re-engineered onto upstream's delegating stream: images stripped once via `stripImagesFromMessages()` before `super._streamResponseChunks`. |
-| Closed (rejected) | `fix/user-after-tool` | [#55](https://github.com/danny-avila/agents/pull/55) | "400 Unexpected role 'user' after role 'tool'" bridge in `formatAgentMessages`. **Dropped** — upstream rejected it and handles role ordering in MultiAgentGraph's handoff path instead. |
-| Closed (rejected) | `fix/wrong-agent-id` | [#61](https://github.com/danny-avila/agents/pull/61) | Handoff: return wrong-tool correction to LLM. **Dropped** — upstream's `shouldHandleUnknownHandoffLocally` + `getUnknownToolErrorMessage` supersedes it. |
+| Open | `feat/vision-capability` | [#257](https://github.com/danny-avila/agents/pull/257) | Optional vision gating: a `vision` constructor flag + `stripImagesFromMessages()` that strips `image_url` parts before `super._streamResponseChunks` when the model lacks vision support. **Clean minimal re-attempt** (3 files, with tests); supersedes the closed #48. Consumed by LibreChat [#13860](https://github.com/danny-avila/LibreChat/pull/13860). |
 | Open | `feat/custom-reranker-provider` | [#66](https://github.com/danny-avila/agents/pull/66) | Custom reranker provider (configurable URL + model). **Kept.** |
 
 ### arabold/docs-mcp-server
@@ -159,4 +157,4 @@ Status verified and customizations decided during the 2026-06 upstream sync (for
 
 ### Notes
 
-- Vision is re-enabled in `packages/librechat-init/config/librechat.yaml` as **experimental/WIP**. Requires `feat/vision` in `dev/librechat` and `dev/agents`. See [WIP Documentation](wip/README.md).
+- Vision is re-enabled in `packages/librechat-init/config/librechat.yaml` as **experimental/WIP**. Requires the vision customizations in the `dev/librechat` and `dev/agents` forks (merged into fork main during the 2026-06 sync). Clean upstream re-attempts: [agents#257](https://github.com/danny-avila/agents/pull/257) + [LibreChat#13860](https://github.com/danny-avila/LibreChat/pull/13860). See [WIP Documentation](wip/README.md).

--- a/docs/wip/README.md
+++ b/docs/wip/README.md
@@ -6,22 +6,21 @@ Work-in-progress notes and design docs for vision handling, YTPTube production, 
 
 Works locally; on server (e.g. Hetzner), blocking (geo/bot) may apply. See [YTPTUBE_FUTURE_WORK.md](YTPTUBE_FUTURE_WORK.md) for production options and [TODO.md](../TODO.md) for the tracked task.
 
-## Branch Status & Upstream Sync (Jan 2025)
+## Branch Status & Upstream Sync (2026-06)
 
-Vision is **re-enabled as experimental/WIP**. Implementation lives on `feat/vision` in submodules; config in this repo is active and explicitly marked WIP.
+Vision is **re-enabled as experimental/WIP**. The implementation is merged into fork `main` for both `dev/librechat` and `dev/agents` (during the 2026-06 upstream sync); config in this repo is active and explicitly marked WIP.
 
 | Aspect | Details |
 |--------|---------|
-| **Submodules** | `dev/librechat`, `dev/agents` |
-| **Feature branch** | `feat/vision` (required for vision to work) |
+| **Submodules** | `dev/librechat`, `dev/agents` (vision on fork `main`) |
 | **Status** | **Experimental/WIP** – not merged upstream yet |
-| **Draft PRs** | [LibreChat PR #11501](https://github.com/danny-avila/LibreChat/pull/11501) (modelSpecs vision flag), [agents PR #48](https://github.com/danny-avila/agents/pull/48) (base64 artifact filtering) |
+| **Upstream re-attempts** | [agents PR #257](https://github.com/danny-avila/agents/pull/257) (`vision` flag + image stripping before streaming) and [LibreChat PR #13860](https://github.com/danny-avila/LibreChat/pull/13860) (forwards `vision` onto the OpenAI LLM config) |
 
 **Config:** Vision is turned on in `packages/librechat-init/config/librechat.yaml` and labelled WIP/experimental:
 - Agents capability: `- "vision"` (around line 102) with comment `# WIP/experimental`
-- Model specs: `vision: true` on vision-capable models (Scaleway Pixtral/Mistral Small, OpenRouter Claude/GPT/Gemini). Section header references draft PRs.
+- Model specs: `vision: true` on vision-capable models (Scaleway Pixtral/Mistral Small, OpenRouter Claude/GPT/Gemini).
 
-To bring submodule `main` in line with upstream while keeping vision on `feat/vision`, use **[Submodule Sync Guide](../SUBMODULE_SYNC.md)** (`npm run update:submodules:status`, `npm run update:submodules`, `npm run update:submodules:dry-run`).
+To keep the forks in line with upstream, use **[Submodule Sync Guide](../SUBMODULE_SYNC.md)** (`npm run update:submodules:status`, `npm run update:submodules`, `npm run update:submodules:dry-run`).
 
 ## Contents
 


### PR DESCRIPTION
Brings the upstream-PR docs up to date after the vision re-attempts and removes the closed/superseded ones.

- Link the new clean vision PRs: [agents#257](https://github.com/danny-avila/agents/pull/257) and [LibreChat#13860](https://github.com/danny-avila/LibreChat/pull/13860).
- Remove closed/superseded PRs: agents #48/#55/#61, LibreChat #11501/#11504.
- Update the vision WIP notes (`docs/wip/README.md`, `docs/README.md`): the feature is merged into the forks' `main`; `feat/vision` branch references replaced.
- Refresh the Upstream Contributions tables and the related Known-Issues entries in `docs/TODO.md`.

Open issues referenced from VISION_ARCHITECTURE.md (#11418/#11413/#11333/#10996) are still valid and left as-is.