### PR TITLE
chore(librechat): bump fork pointer to include open-weight pricing

### DIFF
--- a/.github/workflows/build-librechat.yml
+++ b/.github/workflows/build-librechat.yml
@@ -64,7 +64,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # tsdown (agents build) requires node ^22.18.0 || >=24.0.0; on node 20 it
+          # falls back to the optional `unrun` config loader and fails. Match LibreChat's runtime.
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: dev/agents/package-lock.json
 


### PR DESCRIPTION
Moves `dev/librechat` from `545b7dd` to fork `main` (`7c4cf5e8`), a **2-commit** fast-forward:
1. the June upstream sync (fork PR #1, already on fork main but not yet deployed),
2. our open-weight token pricing (devstral / mistral-medium / voxtral / holo2) — mirrors merged upstream danny-avila/LibreChat#13863, in the already-clean form (no redundant `voxtral-small`, removed upstream in #13867).

Prune the local pricing commit when upstream `main` lands #13863. Triggers the LibreChat image rebuild so the pricing ships.

Note: functionally low-impact for our curated Scaleway models (they are already priced exactly via the `tokenConfig` in #38); this just gives sane fallback pricing for any fetched-but-unlisted model instead of the $6/1M default.