### PR TITLE
feat(spend-monitor): optional org-wide hard stop + manage basic-auth in setup-env

### DIFF
--- a/docker-compose.spend-monitor.yml
+++ b/docker-compose.spend-monitor.yml
@@ -1,6 +1,7 @@
 services:
   spend-monitor:
-    # Read-only org cost monitor. Browser-facing status page exposed via Traefik;
+    # Org cost monitor (read-only by default; opt-in balance enforcement via SPEND_MONITOR_ENFORCE).
+    # Browser-facing status page exposed via Traefik;
     # Traefik labels (and basic auth for prod/dev) are set in the extension files.
     # Build overridden in docker-compose.local.yml; prod/dev pull from the registry.
     image: ghcr.io/faktenforum/spend-monitor:latest

--- a/docs/SPEND_MONITOR.md
+++ b/docs/SPEND_MONITOR.md
@@ -1,18 +1,20 @@
 # Spend Monitor
 
-Read-only org-wide cost monitor for LibreChat. It aggregates spend from the
-`transactions` collection in LibreChat's MongoDB and serves an in-platform
-status page. It does **not** write to LibreChat's database and does **not**
-enforce limits — per-user limits stay in LibreChat's own balance system.
+Org-wide cost monitor for LibreChat. It aggregates spend from the `transactions`
+collection in LibreChat's MongoDB and serves an in-platform status page.
 
-This is the observability layer (Phase 1). Hard enforcement (zeroing balances),
-a Scaleway billing webhook, and email/webhook alerts are possible later phases.
+**Read-only by default.** Optionally it enforces an org-wide hard cap by zeroing
+user balances when spend reaches 100% of the budget (`SPEND_MONITOR_ENFORCE`).
+Per-user limits stay in LibreChat's own balance system either way.
+
+A Scaleway billing webhook and email/webhook alerts are possible later phases.
 
 ## Endpoints
 
 - `GET /health` — liveness
 - `GET /api/spend` — current-period spend JSON (org total, per-provider, per-model, top users)
 - `GET /` — HTML status page (auto-refreshes every 30s)
+- `POST /restore` — lift enforcement and restore balances (only when enforce is `on`/`dry-run`)
 
 Local: `http://localhost:3016` and `http://spend.localhost`. Prod/dev: `https://spend.${DOMAIN}` (behind Traefik basic auth).
 
@@ -38,6 +40,7 @@ Spend is recorded after a completion, so the total trails real spend by at most 
 | `SPEND_MONITOR_CRIT_PCT` | `80` | critical threshold (%) |
 | `SPEND_MONITOR_EUR_RATE` | `0.92` | EUR per USD, display only |
 | `SPEND_MONITOR_POLL_SECONDS` | `60` | aggregation interval |
+| `SPEND_MONITOR_ENFORCE` | `off` | `off` / `dry-run` / `on` — hard stop by zeroing balances |
 | `SPEND_MONITOR_BASIC_AUTH` | — | prod/dev: Traefik basic-auth htpasswd line |
 
 The MongoDB URI is not configured separately — the service reuses LibreChat's
@@ -48,6 +51,25 @@ The MongoDB URI is not configured separately — the service reuses LibreChat's
 In-platform only for now: the status-page banner turns amber/orange/red at the
 warn/crit/over thresholds, and each level transition is logged (structured Pino
 warning at crit/over). Email and webhook notifiers are stubbed for a later phase.
+
+## Enforcement (optional hard stop)
+
+`SPEND_MONITOR_ENFORCE` (default `off`):
+
+- `off` — monitor only, never writes to LibreChat's database.
+- `dry-run` — logs what it *would* zero/restore but writes nothing. Use this first.
+- `on` — when spend reaches 100% of budget, it snapshots all balances, sets every
+  `tokenCredits` to 0 and disables auto-refill, so LibreChat's pre-request balance
+  check blocks all further requests. It re-zeroes each poll (catching in-flight spend
+  and newly created users), **auto-restores** when the period resets or the budget is
+  raised (spend < budget), and can be lifted manually via the dashboard's **Restore**
+  button (`POST /restore`).
+
+Snapshot and enforcement state live in the `spendmonitor_balance_snapshot` and
+`spendmonitor_state` collections (the monitor's own, not LibreChat's). There is a lag
+of up to one poll + in-flight requests before the cap bites (spend is recorded after a
+completion), so set the budget slightly below the true ceiling. Coarse by design: it
+cuts off all users at once.
 
 ## Basic auth (prod/dev)
 

--- a/env.dev.example
+++ b/env.dev.example
@@ -48,7 +48,8 @@ GOOGLE_KEY=
 # FIRECRAWL_API_URL=http://${STACK_NAME:-prod}-firecrawl-api:3002
 
 # Spend Monitor (read-only org cost dashboard; reuses LibreChat's MongoDB)
-SPEND_MONITOR_BUDGET_USD=100          # set your monthly org budget in USD
+# set your monthly org budget in USD
+SPEND_MONITOR_BUDGET_USD=100
 SPEND_MONITOR_PERIOD=calendar-month
 SPEND_MONITOR_WARN_PCT=50
 SPEND_MONITOR_CRIT_PCT=80

--- a/env.dev.example
+++ b/env.dev.example
@@ -54,6 +54,9 @@ SPEND_MONITOR_WARN_PCT=50
 SPEND_MONITOR_CRIT_PCT=80
 SPEND_MONITOR_EUR_RATE=0.92
 SPEND_MONITOR_POLL_SECONDS=60
+# Hard stop: off (monitor only) | dry-run (log only, no writes) | on (zero balances at 100% budget).
+# Start with dry-run to validate before switching to on. See docs/SPEND_MONITOR.md.
+SPEND_MONITOR_ENFORCE=off
 # Basic auth for the Traefik-exposed dashboard (sensitive cost data). htpasswd line "user:bcrypt-hash".
 # Generate: htpasswd -nbB admin 'password'  (REQUIRED; see docs/SPEND_MONITOR.md for the $ escaping note)
 SPEND_MONITOR_BASIC_AUTH=

--- a/env.local.example
+++ b/env.local.example
@@ -181,6 +181,9 @@ SPEND_MONITOR_EUR_RATE=0.92
 SPEND_MONITOR_POLL_SECONDS=60
 # Hard stop: off (monitor only) | dry-run (log only, no writes) | on (zero balances at 100% budget)
 SPEND_MONITOR_ENFORCE=off
+# Basic auth for the dashboard, htpasswd line "user:hash" (generate: htpasswd -nbB admin <password>).
+# Enforced via Traefik in prod/dev; local is localhost-bound and does not enforce it.
+SPEND_MONITOR_BASIC_AUTH=
 
 # MCP Firecrawl Server
 MCP_FIRECRAWL_PORT=3003

--- a/env.local.example
+++ b/env.local.example
@@ -179,6 +179,8 @@ SPEND_MONITOR_WARN_PCT=50
 SPEND_MONITOR_CRIT_PCT=80
 SPEND_MONITOR_EUR_RATE=0.92
 SPEND_MONITOR_POLL_SECONDS=60
+# Hard stop: off (monitor only) | dry-run (log only, no writes) | on (zero balances at 100% budget)
+SPEND_MONITOR_ENFORCE=off
 
 # MCP Firecrawl Server
 MCP_FIRECRAWL_PORT=3003

--- a/env.prod.example
+++ b/env.prod.example
@@ -41,7 +41,8 @@ GOOGLE_KEY=
 # FIRECRAWL_API_URL=http://${STACK_NAME:-prod}-firecrawl-api:3002
 
 # Spend Monitor (read-only org cost dashboard; reuses LibreChat's MongoDB)
-SPEND_MONITOR_BUDGET_USD=100          # set your monthly org budget in USD
+# set your monthly org budget in USD
+SPEND_MONITOR_BUDGET_USD=100
 SPEND_MONITOR_PERIOD=calendar-month
 SPEND_MONITOR_WARN_PCT=50
 SPEND_MONITOR_CRIT_PCT=80

--- a/env.prod.example
+++ b/env.prod.example
@@ -47,6 +47,9 @@ SPEND_MONITOR_WARN_PCT=50
 SPEND_MONITOR_CRIT_PCT=80
 SPEND_MONITOR_EUR_RATE=0.92
 SPEND_MONITOR_POLL_SECONDS=60
+# Hard stop: off (monitor only) | dry-run (log only, no writes) | on (zero balances at 100% budget).
+# Start with dry-run to validate before switching to on. See docs/SPEND_MONITOR.md.
+SPEND_MONITOR_ENFORCE=off
 # Basic auth for the Traefik-exposed dashboard (sensitive cost data). htpasswd line "user:bcrypt-hash".
 # Generate: htpasswd -nbB admin 'password'  (REQUIRED in prod; see docs/SPEND_MONITOR.md for the $ escaping note)
 SPEND_MONITOR_BASIC_AUTH=

--- a/packages/spend-monitor/README.md
+++ b/packages/spend-monitor/README.md
@@ -1,9 +1,9 @@
 # spend-monitor
 
-Read-only org-wide cost monitor for LibreChat. Aggregates spend from the
-`transactions` collection in LibreChat's MongoDB and serves an in-platform
-status page. It does **not** write to LibreChat's database and does **not**
-enforce any limit (per-user limits stay in LibreChat's own balance system).
+Org-wide cost monitor for LibreChat. Aggregates spend from the `transactions`
+collection in LibreChat's MongoDB and serves an in-platform status page.
+Read-only by default; can optionally enforce an org hard cap by zeroing balances
+when over budget (`SPEND_MONITOR_ENFORCE`). Per-user limits stay in LibreChat.
 
 ## Endpoints
 
@@ -24,6 +24,7 @@ enforce any limit (per-user limits stay in LibreChat's own balance system).
 | `SPEND_MONITOR_CRIT_PCT` | `80` | critical threshold (%) |
 | `SPEND_MONITOR_EUR_RATE` | `0.92` | EUR per USD, display only |
 | `SPEND_MONITOR_POLL_SECONDS` | `60` | aggregation interval |
+| `SPEND_MONITOR_ENFORCE` | `off` | `off`/`dry-run`/`on` — hard stop by zeroing balances |
 
 Spend uses LibreChat's convention: `1,000,000 token credits = 1 USD`. `tokenValue`
 is negative for usage; `tokenType: 'credits'` rows (refills) are excluded.

--- a/packages/spend-monitor/src/config.ts
+++ b/packages/spend-monitor/src/config.ts
@@ -1,8 +1,11 @@
 import 'dotenv/config';
+import type { EnforceMode } from './enforce.ts';
 
 export type Period = 'calendar-month' | 'rolling-30d';
 
 export interface Config {
+  /** off (monitor only) | dry-run (log what it would do) | on (zero balances over budget) */
+  enforce: EnforceMode;
   port: number;
   mongoUri: string;
   dbName: string;
@@ -24,7 +27,9 @@ function num(name: string, def: number): number {
 
 export function loadConfig(): Config {
   const rawPeriod = process.env.SPEND_MONITOR_PERIOD;
+  const rawEnforce = process.env.SPEND_MONITOR_ENFORCE;
   return {
+    enforce: rawEnforce === 'on' ? 'on' : rawEnforce === 'dry-run' ? 'dry-run' : 'off',
     port: num('PORT', 3016),
     mongoUri: process.env.SPEND_MONITOR_MONGO_URI || 'mongodb://prod-mongodb:27017/LibreChat',
     dbName: process.env.SPEND_MONITOR_DB || 'LibreChat',

--- a/packages/spend-monitor/src/enforce.ts
+++ b/packages/spend-monitor/src/enforce.ts
@@ -1,0 +1,153 @@
+import type { Db } from 'mongodb';
+import { logger } from './utils/logger.ts';
+
+export type EnforceMode = 'off' | 'dry-run' | 'on';
+
+const BALANCES = 'balances';
+const STATE = 'spendmonitor_state';
+const SNAPSHOT = 'spendmonitor_balance_snapshot';
+
+export interface EnforceState {
+  active: boolean;
+  since: string | null;
+  reason: string | null;
+  /** When set, auto-enforcement is suppressed while the period equals this value
+   *  (admin "Restore" override: keep users working over budget until the period resets). */
+  overridePeriodStart: string | null;
+}
+
+interface StateDoc extends EnforceState {
+  _id: string;
+}
+
+interface BalanceDoc {
+  user: unknown;
+  tokenCredits: number;
+  autoRefillEnabled?: boolean;
+}
+
+interface SnapshotDoc {
+  user: unknown;
+  tokenCredits: number;
+  autoRefillEnabled: boolean;
+}
+
+export async function getEnforceState(db: Db): Promise<EnforceState> {
+  const doc = await db.collection<StateDoc>(STATE).findOne({ _id: 'enforcement' });
+  return {
+    active: Boolean(doc?.active),
+    since: doc?.since ?? null,
+    reason: doc?.reason ?? null,
+    overridePeriodStart: doc?.overridePeriodStart ?? null,
+  };
+}
+
+async function setEnforceState(db: Db, state: EnforceState): Promise<void> {
+  await db
+    .collection<StateDoc>(STATE)
+    .updateOne({ _id: 'enforcement' }, { $set: { ...state } }, { upsert: true });
+}
+
+/** Clear a stale admin override once the billing period has rolled over. */
+export async function clearStaleOverride(db: Db, currentPeriodStart: string): Promise<void> {
+  const st = await getEnforceState(db);
+  if (st.overridePeriodStart != null && st.overridePeriodStart !== currentPeriodStart) {
+    await setEnforceState(db, { ...st, overridePeriodStart: null });
+  }
+}
+
+/**
+ * Snapshot balances (once, on activation) then zero them and disable auto-refill.
+ * Idempotent: safe to call every poll while over budget - it re-zeroes balances that
+ * crept above 0 (in-flight spends, lazily-created new users) and keeps auto-refill off
+ * so LibreChat's own refill cannot re-credit users mid-freeze.
+ */
+export async function enforceCap(
+  db: Db,
+  reason: string,
+  nowIso: string,
+  dryRun: boolean,
+): Promise<{ snapshotted: number; zeroed: number }> {
+  const balances = db.collection<BalanceDoc>(BALANCES);
+  const snapshot = db.collection<SnapshotDoc>(SNAPSHOT);
+
+  let snapshotted = 0;
+  const state = await getEnforceState(db);
+  if (!state.active) {
+    const docs = await balances
+      .find({}, { projection: { user: 1, tokenCredits: 1, autoRefillEnabled: 1 } })
+      .toArray();
+    snapshotted = docs.length;
+    if (dryRun) {
+      logger.warn({ wouldSnapshot: snapshotted, reason }, 'DRY-RUN: would snapshot balances + start enforcement');
+    } else {
+      await snapshot.deleteMany({});
+      if (docs.length > 0) {
+        await snapshot.insertMany(
+          docs.map((d) => ({
+            user: d.user,
+            tokenCredits: d.tokenCredits ?? 0,
+            autoRefillEnabled: d.autoRefillEnabled ?? false,
+          })),
+        );
+      }
+      await setEnforceState(db, { active: true, since: nowIso, reason, overridePeriodStart: null });
+      logger.warn({ snapshotted, reason }, 'ENFORCEMENT ON: snapshotted balances; zeroing');
+    }
+  }
+
+  const overZero = { $or: [{ tokenCredits: { $gt: 0 } }, { autoRefillEnabled: true }] };
+  if (dryRun) {
+    const n = await balances.countDocuments(overZero);
+    logger.warn({ wouldZero: n }, 'DRY-RUN: would zero balances + disable auto-refill');
+    return { snapshotted, zeroed: 0 };
+  }
+  const result = await balances.updateMany(overZero, {
+    $set: { tokenCredits: 0, autoRefillEnabled: false },
+  });
+  return { snapshotted, zeroed: result.modifiedCount };
+}
+
+/**
+ * Restore snapshotted balances, lift enforcement, and re-enable auto-refill for any
+ * user who joined during the freeze. Pass `overridePeriodStart` to suppress
+ * auto-re-enforcement for that period (manual admin override); pass null to clear it
+ * (auto-restore after a period reset / budget raise).
+ */
+export async function restoreBalances(
+  db: Db,
+  dryRun: boolean,
+  overridePeriodStart: string | null,
+): Promise<{ restored: number }> {
+  const balances = db.collection<BalanceDoc>(BALANCES);
+  const snapshot = db.collection<SnapshotDoc>(SNAPSHOT);
+  const snaps = await snapshot.find({}).toArray();
+
+  if (dryRun) {
+    logger.warn({ wouldRestore: snaps.length }, 'DRY-RUN: would restore balances + lift enforcement');
+    return { restored: snaps.length };
+  }
+
+  if (snaps.length > 0) {
+    await balances.bulkWrite(
+      snaps.map((s) => ({
+        updateOne: {
+          filter: { user: s.user },
+          update: {
+            $set: { tokenCredits: s.tokenCredits ?? 0, autoRefillEnabled: s.autoRefillEnabled ?? false },
+          },
+        },
+      })),
+    );
+    const snapUsers = snaps.map((s) => s.user);
+    await balances.updateMany(
+      { user: { $nin: snapUsers }, autoRefillEnabled: false },
+      { $set: { autoRefillEnabled: true } },
+    );
+  }
+
+  await snapshot.deleteMany({});
+  await setEnforceState(db, { active: false, since: null, reason: null, overridePeriodStart });
+  logger.warn({ restored: snaps.length, overridePeriodStart }, 'ENFORCEMENT OFF: balances restored');
+  return { restored: snaps.length };
+}

--- a/packages/spend-monitor/src/page.ts
+++ b/packages/spend-monitor/src/page.ts
@@ -1,4 +1,5 @@
 import type { Level, Snapshot } from './aggregate.ts';
+import type { EnforceMode, EnforceState } from './enforce.ts';
 
 const COLORS: Record<Level, { bg: string; fg: string; label: string }> = {
   ok: { bg: '#065f46', fg: '#d1fae5', label: 'OK' },
@@ -24,7 +25,24 @@ function rows(cells: string[][]): string {
   return cells.map((r) => `<tr>${r.map((c) => `<td>${c}</td>`).join('')}</tr>`).join('');
 }
 
-export function renderPage(s: Snapshot): string {
+function enforceStrip(mode: EnforceMode, e: EnforceState): string {
+  if (e.active) {
+    const dry = mode === 'dry-run' ? ' (DRY-RUN)' : '';
+    return `<div class="enforce active">
+      <strong>&#9940; Enforcement active${dry}</strong> &mdash; all user balances zeroed since <code>${esc(e.since ?? '')}</code>. ${esc(e.reason ?? '')}
+      <button onclick="if(confirm('Restore all balances and lift the spending freeze?')){this.disabled=true;fetch('/restore',{method:'POST'}).then(()=>location.reload())}">Restore balances</button>
+    </div>`;
+  }
+  if (e.overridePeriodStart != null) {
+    return `<div class="enforce armed">Admin override: freeze lifted for this period &mdash; auto-enforcement re-engages next period if still over budget.</div>`;
+  }
+  if (mode !== 'off') {
+    return `<div class="enforce armed">Enforcement armed: <code>${mode}</code> &mdash; balances are zeroed automatically when spend reaches 100% of budget.</div>`;
+  }
+  return '';
+}
+
+export function renderPage(s: Snapshot, mode: EnforceMode, enforcement: EnforceState): string {
   const c = COLORS[s.level];
   const pct = Math.round(s.usedRatio * 100);
   const barWidth = Math.min(100, pct);
@@ -33,11 +51,7 @@ export function renderPage(s: Snapshot): string {
     ['OpenRouter', usd(s.byProvider.openrouter)],
     ['Scaleway', usd(s.byProvider.scaleway)],
   ]);
-
-  const modelRows = rows(
-    s.byModel.slice(0, 20).map((m) => [esc(m.model), m.provider, usd(m.usd)]),
-  );
-
+  const modelRows = rows(s.byModel.slice(0, 20).map((m) => [esc(m.model), m.provider, usd(m.usd)]));
   const userRows = rows(s.topUsers.map((u) => [esc(u.user), usd(u.usd)]));
 
   return `<!doctype html>
@@ -58,6 +72,10 @@ export function renderPage(s: Snapshot): string {
   .sub { font-size: 0.9rem; opacity: 0.9; }
   .bar { height: 8px; background: rgba(255,255,255,0.2); border-radius: 999px; margin-top: 0.9rem; overflow: hidden; }
   .bar > span { display: block; height: 100%; width: ${barWidth}%; background: rgba(255,255,255,0.85); }
+  .enforce { border-radius: 10px; padding: 0.8rem 1.1rem; margin-top: 1rem; font-size: 0.9rem; }
+  .enforce.active { background: #7f1d1d; color: #fee2e2; }
+  .enforce.armed { background: #1f2937; color: #9ca3af; }
+  .enforce button { margin-left: 0.6rem; background: #fee2e2; color: #7f1d1d; border: 0; border-radius: 6px; padding: 0.35rem 0.7rem; font-weight: 600; cursor: pointer; }
   table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.9rem; }
   th, td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid #1f2937; }
   td:last-child, th:last-child { text-align: right; font-variant-numeric: tabular-nums; }
@@ -69,13 +87,15 @@ export function renderPage(s: Snapshot): string {
 </head>
 <body>
 <div class="wrap">
-  <h1>LibreChat &mdash; org spend monitor (read-only)</h1>
+  <h1>LibreChat &mdash; org spend monitor</h1>
   <div class="banner">
     <div class="level">${c.label} &middot; ${pct}% of budget</div>
     <div class="headline">${usd(s.spentUsd)} <span style="opacity:.6;font-size:1.2rem">/ ${usd(s.budgetUsd)}</span></div>
     <div class="sub">${eur(s.eur.spent)} / ${eur(s.eur.budget)} &middot; period: ${s.period}</div>
     <div class="bar"><span></span></div>
   </div>
+
+  ${enforceStrip(mode, enforcement)}
 
   <section>
     <h2>By provider</h2>
@@ -94,7 +114,7 @@ export function renderPage(s: Snapshot): string {
 
   <footer>
     period start <code>${esc(s.periodStart)}</code> &middot; updated <code>${esc(s.updatedAt)}</code> &middot; auto-refresh 30s &middot;
-    1,000,000 credits = $1 &middot; EUR is display-only (rate ${s.eur.rate})
+    enforce: <code>${mode}</code> &middot; 1,000,000 credits = $1 &middot; EUR display rate ${s.eur.rate}
   </footer>
 </div>
 </body>

--- a/packages/spend-monitor/src/server.ts
+++ b/packages/spend-monitor/src/server.ts
@@ -3,10 +3,14 @@
 /**
  * Spend Monitor
  *
- * Read-only org-wide cost monitor for LibreChat. Periodically aggregates spend
- * from the `transactions` collection in LibreChat's MongoDB, serves an in-platform
- * status page (GET /) and JSON (GET /api/spend), and logs level transitions.
- * It never writes to LibreChat's database.
+ * Aggregates org-wide spend from LibreChat's `transactions` collection and serves an
+ * in-platform status page (GET /) and JSON (GET /api/spend).
+ *
+ * Read-only by default. When SPEND_MONITOR_ENFORCE is `on` (or `dry-run`), it adds an
+ * org-wide HARD STOP: once spend reaches 100% of the budget it snapshots and zeroes all
+ * user balances (and disables auto-refill) so LibreChat's own pre-request balance check
+ * blocks further requests. It auto-restores when the period resets (spend < budget) and
+ * can be lifted manually via POST /restore.
  */
 
 import 'dotenv/config';
@@ -18,6 +22,8 @@ import { connectMongo, closeMongo } from './mongo.ts';
 import { aggregate } from './aggregate.ts';
 import type { Level, Snapshot } from './aggregate.ts';
 import { logNotifier } from './notify.ts';
+import { getEnforceState, enforceCap, restoreBalances, clearStaleOverride } from './enforce.ts';
+import type { EnforceState } from './enforce.ts';
 import { renderPage } from './page.ts';
 import { logger } from './utils/logger.ts';
 
@@ -30,10 +36,31 @@ async function main(): Promise<void> {
 
   let latest: Snapshot | null = null;
   let prevLevel: Level = 'ok';
+  let enforceState: EnforceState = { active: false, since: null, reason: null };
 
   async function refresh(): Promise<void> {
     try {
       const snap = await aggregate(db, cfg, new Date());
+
+      if (cfg.enforce !== 'off') {
+        const dryRun = cfg.enforce === 'dry-run';
+        await clearStaleOverride(db, snap.periodStart);
+        const st = await getEnforceState(db);
+        const suppressed = st.overridePeriodStart === snap.periodStart;
+        if (snap.level === 'over' && !suppressed) {
+          await enforceCap(
+            db,
+            `org budget exceeded: $${snap.spentUsd.toFixed(2)} / $${snap.budgetUsd.toFixed(2)}`,
+            new Date().toISOString(),
+            dryRun,
+          );
+        } else if (st.active && snap.level !== 'over') {
+          // spend dropped below budget (period reset or budget raised) -> lift the freeze
+          await restoreBalances(db, dryRun, null);
+        }
+        enforceState = await getEnforceState(db);
+      }
+
       if (snap.level !== prevLevel) {
         logNotifier.notify(prevLevel, snap);
         prevLevel = snap.level;
@@ -42,7 +69,7 @@ async function main(): Promise<void> {
     } catch (error) {
       logger.error(
         { error: error instanceof Error ? error.message : String(error) },
-        'Spend aggregation failed',
+        'Spend refresh failed',
       );
     }
   }
@@ -62,7 +89,7 @@ async function main(): Promise<void> {
       res.status(503).json({ error: 'no data yet' });
       return;
     }
-    res.json(latest);
+    res.json({ ...latest, enforce: cfg.enforce, enforcement: enforceState });
   });
 
   app.get('/', async (_req: Request, res: Response) => {
@@ -71,12 +98,30 @@ async function main(): Promise<void> {
       res.status(503).send('no data yet');
       return;
     }
-    res.type('html').send(renderPage(latest));
+    res.type('html').send(renderPage(latest, cfg.enforce, enforceState));
+  });
+
+  // Manually lift enforcement and restore balances (the dashboard's "Restore" button).
+  app.post('/restore', async (_req: Request, res: Response) => {
+    if (cfg.enforce === 'off') {
+      res.status(400).json({ error: 'enforcement disabled (SPEND_MONITOR_ENFORCE=off)' });
+      return;
+    }
+    // Admin override: lift the freeze and suppress re-enforcement for the current period.
+    const result = await restoreBalances(db, cfg.enforce !== 'on', latest?.periodStart ?? null);
+    await refresh();
+    res.json({ restored: result.restored, dryRun: cfg.enforce !== 'on', suppressedForPeriod: latest?.periodStart ?? null });
   });
 
   const server = app.listen(cfg.port, '0.0.0.0', () => {
     logger.info(
-      { port: cfg.port, budgetUsd: cfg.budgetUsd, period: cfg.period, pollSeconds: cfg.pollSeconds },
+      {
+        port: cfg.port,
+        budgetUsd: cfg.budgetUsd,
+        period: cfg.period,
+        pollSeconds: cfg.pollSeconds,
+        enforce: cfg.enforce,
+      },
       'Spend monitor started',
     );
   });

--- a/scripts/setup-env.ts
+++ b/scripts/setup-env.ts
@@ -65,6 +65,15 @@ const genUsername = (prefix: string = 'admin'): string => {
 };
 
 /**
+ * Escape '$' as '$$' for values consumed through docker-compose ${...} interpolation
+ * (e.g. an htpasswd bcrypt hash in a Traefik label - an unescaped '$' is eaten as a
+ * variable reference and corrupts the hash). Idempotent: collapses any existing '$$'
+ * first, so re-running setup-env never double-escapes.
+ */
+const escapeComposeDollar = (value: string): string =>
+    value ? value.split('$$').join('$').split('$').join('$$') : value;
+
+/**
  * Check if a value contains variable expansions (e.g., ${VAR_NAME})
  */
 const containsVariableExpansion = (value: string): boolean => {
@@ -587,7 +596,9 @@ async function processEnvExample(
                 isProdMode || isDevMode,
                 skipPrompts
             );
-            finalEnvLines.push(`${key}=${value}`);
+            // htpasswd hashes flow into a docker-compose ${...} Traefik label; escape '$' -> '$$'
+            const finalValue = key === 'SPEND_MONITOR_BASIC_AUTH' ? escapeComposeDollar(value) : value;
+            finalEnvLines.push(`${key}=${finalValue}`);
             continue;
         }
 

--- a/scripts/setup-env.ts
+++ b/scripts/setup-env.ts
@@ -242,6 +242,9 @@ const PROMPTS: Record<string, PromptConfig> = {
 
     // MCP Linux - Code index (semantic code search; optional)
     'CODE_INDEX_EMBEDDING_API_KEY': { message: 'Code index embedding API key (optional; OpenRouter or Scaleway for semantic code search):', type: 'password', defaultGen: () => '' },
+
+    // Spend Monitor dashboard - Traefik basic auth (prod/dev). Generate: htpasswd -nbB admin <password>
+    'SPEND_MONITOR_BASIC_AUTH': { message: 'Spend-monitor dashboard basic auth - htpasswd line "user:hash" (enter to skip; required for the prod/dev dashboard):', type: 'password', defaultGen: () => '' },
 };
 
 /**


### PR DESCRIPTION
Supersedes #42 (auto-closed when its base branch `feat/spend-monitor` was deleted on #41's merge; rebased cleanly onto main).

Adds the **opt-in org-wide hard stop** to the spend monitor plus setup-env management of the dashboard basic-auth credential. Stacked work from #41 (already merged).

- **Enforcement** (`SPEND_MONITOR_ENFORCE`, default `off`): `dry-run` logs only; `on` zeroes all balances at 100% of budget (snapshot + auto-restore on period reset + manual `POST /restore` admin override). `src/enforce.ts`, server poll-loop + route, status-page banner + Restore button.
- **setup-env**: `SPEND_MONITOR_BASIC_AUTH` is now a managed PROMPT key (preserved on regen, prompted on fresh) and is **$-escaped** (`$$`) so the bcrypt hash survives docker-compose interpolation into the Traefik label (verified: compose resolves the intact hash).
- Fixes an inline-comment leak on `SPEND_MONITOR_BUDGET_USD` in the prod/dev examples.

Verified locally against a seeded MongoDB (zero/snapshot/restore) and via `docker compose config` (basic-auth hash intact). Enforcement defaults off, so this is safe to ship dark.