### PR TITLE
fix(spend-monitor): pass enforce flag in prod/dev + harden restore/dry-run

### DIFF
--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -404,7 +404,7 @@ services:
     container_name: ${STACK_NAME:-local}-spend-monitor
     env_file: .env.local
     ports:
-      - "127.0.0.1:${SPEND_MONITOR_PORT:-3016}:${SPEND_MONITOR_PORT:-3016}"
+      - "127.0.0.1:${SPEND_MONITOR_PORT:-3016}:3016"
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=ai-chat-interface_traefik-net"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -424,7 +424,7 @@ services:
       context: ./packages/spend-monitor
       dockerfile: Dockerfile
     ports:
-      - "127.0.0.1:${SPEND_MONITOR_PORT:-3016}:${SPEND_MONITOR_PORT:-3016}"
+      - "127.0.0.1:${SPEND_MONITOR_PORT:-3016}:3016"
     # Local only: localhost-bound + spend.localhost. No auth needed on a dev machine.
     labels:
       - "traefik.enable=true"

--- a/docker-compose.spend-monitor.yml
+++ b/docker-compose.spend-monitor.yml
@@ -8,7 +8,9 @@ services:
     restart: always
     environment:
       NODE_ENV: ${NODE_ENV:-production}
-      PORT: ${SPEND_MONITOR_PORT:-3016}
+      # Container port is fixed at 3016 (expose, healthcheck and Traefik all assume it).
+      # SPEND_MONITOR_PORT only remaps the host side of the local port binding.
+      PORT: 3016
       LOG_LEVEL: ${SPEND_MONITOR_LOG_LEVEL:-info}
       # Reuse LibreChat's own MongoDB URI expression verbatim so the monitor always
       # connects to the same database LibreChat uses, in every environment.
@@ -20,6 +22,10 @@ services:
       SPEND_MONITOR_CRIT_PCT: ${SPEND_MONITOR_CRIT_PCT:-80}
       SPEND_MONITOR_EUR_RATE: ${SPEND_MONITOR_EUR_RATE:-0.92}
       SPEND_MONITOR_POLL_SECONDS: ${SPEND_MONITOR_POLL_SECONDS:-60}
+      # off (monitor only) | dry-run (log what it would do) | on (zero balances at 100% of budget).
+      # Must be in this environment block: Portainer ignores env_file, so a label-only
+      # override would never reach the container in prod/dev.
+      SPEND_MONITOR_ENFORCE: ${SPEND_MONITOR_ENFORCE:-off}
     expose:
       - "3016"
     networks:

--- a/docs/SPEND_MONITOR.md
+++ b/docs/SPEND_MONITOR.md
@@ -81,9 +81,10 @@ htpasswd -nbB admin 'your-password'
 # -> admin:$2y$05$....
 ```
 
-Use the full `user:hash` string. If login is rejected when the value comes from
-an env file, double every `$` to `$$` (compose interpolation). Local does not use
-basic auth (localhost-bound + `spend.localhost`).
+Use the full `user:hash` string. `scripts/setup-env.ts` auto-escapes `$` to `$$`
+for compose interpolation (idempotent), so manual doubling is only needed if you
+edit `.env` by hand without running setup-env. Local does not use basic auth
+(localhost-bound + `spend.localhost`).
 
 ## Deploy
 

--- a/env.dev.example
+++ b/env.dev.example
@@ -59,7 +59,7 @@ SPEND_MONITOR_POLL_SECONDS=60
 # Start with dry-run to validate before switching to on. See docs/SPEND_MONITOR.md.
 SPEND_MONITOR_ENFORCE=off
 # Basic auth for the Traefik-exposed dashboard (sensitive cost data). htpasswd line "user:bcrypt-hash".
-# Generate: htpasswd -nbB admin 'password'  (REQUIRED; see docs/SPEND_MONITOR.md for the $ escaping note)
+# Generate: htpasswd -nbB admin 'password'  (REQUIRED; setup-env.ts auto-escapes $ -> $$, see docs/SPEND_MONITOR.md)
 SPEND_MONITOR_BASIC_AUTH=
 # FIRECRAWL_REDIS_URL=redis://${STACK_NAME:-prod}-firecrawl-redis:6379
 # FIRECRAWL_PLAYWRIGHT_MICROSERVICE_URL=http://${STACK_NAME:-prod}-firecrawl-playwright:3000/scrape

--- a/env.local.example
+++ b/env.local.example
@@ -171,6 +171,7 @@ MCP_IMAGE_GEN_LOG_LEVEL=info
 # Uses OPENROUTER_KEY from existing config
 
 # Spend Monitor (read-only org cost dashboard; reuses LibreChat's MongoDB via LIBRECHAT_MONGO_URI)
+# Host port for the local dashboard; the container always listens on 3016.
 SPEND_MONITOR_PORT=3016
 SPEND_MONITOR_LOG_LEVEL=info
 SPEND_MONITOR_BUDGET_USD=100

--- a/env.prod.example
+++ b/env.prod.example
@@ -52,7 +52,7 @@ SPEND_MONITOR_POLL_SECONDS=60
 # Start with dry-run to validate before switching to on. See docs/SPEND_MONITOR.md.
 SPEND_MONITOR_ENFORCE=off
 # Basic auth for the Traefik-exposed dashboard (sensitive cost data). htpasswd line "user:bcrypt-hash".
-# Generate: htpasswd -nbB admin 'password'  (REQUIRED in prod; see docs/SPEND_MONITOR.md for the $ escaping note)
+# Generate: htpasswd -nbB admin 'password'  (REQUIRED in prod; setup-env.ts auto-escapes $ -> $$, see docs/SPEND_MONITOR.md)
 SPEND_MONITOR_BASIC_AUTH=
 # FIRECRAWL_REDIS_URL=redis://${STACK_NAME:-prod}-firecrawl-redis:6379
 # FIRECRAWL_PLAYWRIGHT_MICROSERVICE_URL=http://${STACK_NAME:-prod}-firecrawl-playwright:3000/scrape

--- a/packages/spend-monitor/README.md
+++ b/packages/spend-monitor/README.md
@@ -9,7 +9,7 @@ when over budget (`SPEND_MONITOR_ENFORCE`). Per-user limits stay in LibreChat.
 
 - `GET /health` — liveness, `{status:"ok"}`
 - `GET /api/spend` — current-period spend JSON (org total, per-provider, per-model, top users)
-- `GET /` — HTML status page (auto-refresh 30s)
+- `GET /` — HTML status page (auto-refreshes every `SPEND_MONITOR_POLL_SECONDS`)
 
 ## Config (env)
 
@@ -29,6 +29,11 @@ when over budget (`SPEND_MONITOR_ENFORCE`). Per-user limits stay in LibreChat.
 Spend uses LibreChat's convention: `1,000,000 token credits = 1 USD`. `tokenValue`
 is negative for usage; `tokenType: 'credits'` rows (refills) are excluded.
 Provider split: model ids containing `/` are OpenRouter, bare ids are Scaleway.
+
+Under this repo's compose these are wired up for you: `PORT` is fixed at 3016 (only
+the host side of the local binding follows `SPEND_MONITOR_PORT`) and
+`SPEND_MONITOR_MONGO_URI` defaults to `LIBRECHAT_MONGO_URI`. See
+`docker-compose.spend-monitor.yml`.
 
 ## Run
 

--- a/packages/spend-monitor/src/enforce.ts
+++ b/packages/spend-monitor/src/enforce.ts
@@ -49,18 +49,30 @@ async function setEnforceState(db: Db, state: EnforceState): Promise<void> {
 }
 
 /** Clear a stale admin override once the billing period has rolled over. */
-export async function clearStaleOverride(db: Db, currentPeriodStart: string): Promise<void> {
+export async function clearStaleOverride(
+  db: Db,
+  currentPeriodStart: string,
+  dryRun: boolean,
+): Promise<void> {
   const st = await getEnforceState(db);
   if (st.overridePeriodStart != null && st.overridePeriodStart !== currentPeriodStart) {
+    if (dryRun) {
+      logger.warn(
+        { overridePeriodStart: st.overridePeriodStart, currentPeriodStart },
+        'DRY-RUN: would clear stale override',
+      );
+      return;
+    }
     await setEnforceState(db, { ...st, overridePeriodStart: null });
   }
 }
 
 /**
- * Snapshot balances (once, on activation) then zero them and disable auto-refill.
- * Idempotent: safe to call every poll while over budget - it re-zeroes balances that
- * crept above 0 (in-flight spends, lazily-created new users) and keeps auto-refill off
- * so LibreChat's own refill cannot re-credit users mid-freeze.
+ * Snapshot balances (once, on activation) then zero them. The autoRefillEnabled:false write
+ * is best-effort only - LibreChat's per-request config-sync resets that flag - so the freeze
+ * is actually held by re-zeroing every poll, not by suppressing auto-refill.
+ * Idempotent: safe to call every poll while over budget - it re-zeroes balances that crept
+ * above 0 (in-flight spends, lazily-created new users, or a monthly auto-refill between polls).
  */
 export async function enforceCap(
   db: Db,
@@ -146,8 +158,12 @@ export async function restoreBalances(
     );
   }
 
-  await snapshot.deleteMany({});
+  // Clear enforcement state before dropping the snapshot. A crash in the gap then leaves
+  // active:false with the snapshot still present (recoverable - the next enforceCap re-snapshots
+  // correct values before zeroing), rather than active:true with an empty snapshot (which would
+  // let enforceCap zero balances with nothing left to restore).
   await setEnforceState(db, { active: false, since: null, reason: null, overridePeriodStart });
+  await snapshot.deleteMany({});
   logger.warn({ restored: snaps.length, overridePeriodStart }, 'ENFORCEMENT OFF: balances restored');
   return { restored: snaps.length };
 }

--- a/packages/spend-monitor/src/page.ts
+++ b/packages/spend-monitor/src/page.ts
@@ -42,7 +42,12 @@ function enforceStrip(mode: EnforceMode, e: EnforceState): string {
   return '';
 }
 
-export function renderPage(s: Snapshot, mode: EnforceMode, enforcement: EnforceState): string {
+export function renderPage(
+  s: Snapshot,
+  mode: EnforceMode,
+  enforcement: EnforceState,
+  pollSeconds: number,
+): string {
   const c = COLORS[s.level];
   const pct = Math.round(s.usedRatio * 100);
   const barWidth = Math.min(100, pct);
@@ -59,7 +64,7 @@ export function renderPage(s: Snapshot, mode: EnforceMode, enforcement: EnforceS
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta http-equiv="refresh" content="30" />
+<meta http-equiv="refresh" content="${pollSeconds}" />
 <title>LibreChat spend monitor</title>
 <style>
   :root { color-scheme: light dark; }
@@ -113,7 +118,7 @@ export function renderPage(s: Snapshot, mode: EnforceMode, enforcement: EnforceS
   </section>
 
   <footer>
-    period start <code>${esc(s.periodStart)}</code> &middot; updated <code>${esc(s.updatedAt)}</code> &middot; auto-refresh 30s &middot;
+    period start <code>${esc(s.periodStart)}</code> &middot; updated <code>${esc(s.updatedAt)}</code> &middot; auto-refresh ${pollSeconds}s &middot;
     enforce: <code>${mode}</code> &middot; 1,000,000 credits = $1 &middot; EUR display rate ${s.eur.rate}
   </footer>
 </div>

--- a/packages/spend-monitor/src/server.ts
+++ b/packages/spend-monitor/src/server.ts
@@ -8,9 +8,10 @@
  *
  * Read-only by default. When SPEND_MONITOR_ENFORCE is `on` (or `dry-run`), it adds an
  * org-wide HARD STOP: once spend reaches 100% of the budget it snapshots and zeroes all
- * user balances (and disables auto-refill) so LibreChat's own pre-request balance check
- * blocks further requests. It auto-restores when the period resets (spend < budget) and
- * can be lifted manually via POST /restore.
+ * user balances so LibreChat's own pre-request balance check blocks further requests. The
+ * freeze is held by re-zeroing balances every poll - LibreChat's per-request config-sync
+ * resets the autoRefillEnabled flag, so disabling auto-refill is not relied on. It
+ * auto-restores when the period resets (spend < budget) and can be lifted via POST /restore.
  */
 
 import 'dotenv/config';
@@ -36,7 +37,7 @@ async function main(): Promise<void> {
 
   let latest: Snapshot | null = null;
   let prevLevel: Level = 'ok';
-  let enforceState: EnforceState = { active: false, since: null, reason: null };
+  let enforceState: EnforceState = { active: false, since: null, reason: null, overridePeriodStart: null };
 
   async function refresh(): Promise<void> {
     try {
@@ -44,7 +45,7 @@ async function main(): Promise<void> {
 
       if (cfg.enforce !== 'off') {
         const dryRun = cfg.enforce === 'dry-run';
-        await clearStaleOverride(db, snap.periodStart);
+        await clearStaleOverride(db, snap.periodStart, dryRun);
         const st = await getEnforceState(db);
         const suppressed = st.overridePeriodStart === snap.periodStart;
         if (snap.level === 'over' && !suppressed) {
@@ -98,7 +99,7 @@ async function main(): Promise<void> {
       res.status(503).send('no data yet');
       return;
     }
-    res.type('html').send(renderPage(latest, cfg.enforce, enforceState));
+    res.type('html').send(renderPage(latest, cfg.enforce, enforceState, cfg.pollSeconds));
   });
 
   // Manually lift enforcement and restore balances (the dashboard's "Restore" button).


### PR DESCRIPTION
Round-off of the cost-control + spend-monitor change set before the prod deploy. Found by an adversarial review of everything merged this session; this PR applies the confirmed findings.

## Bugs
- **Enforcement was dead in prod/dev.** `SPEND_MONITOR_ENFORCE` was never in the compose `environment:` block, so under Portainer (which ignores `env_file`) `config.ts` always resolved `enforce: off` - exactly where balances are enabled. Now passed through as `${SPEND_MONITOR_ENFORCE:-off}`.
- **restoreBalances crash window.** The snapshot was dropped before enforcement state was cleared; a crash in between left `active:true` with an empty snapshot, after which the next poll would zero balances with nothing left to restore. Reordered: clear state first, then drop the snapshot.
- **Type error.** The initial `enforceState` literal in `server.ts` omitted the required `overridePeriodStart`, failing `tsc --noEmit` (TS2741).

## Consistency / docs
- Port indirection: `PORT` is fixed at 3016 (expose, healthcheck and Traefik all assume it); `SPEND_MONITOR_PORT` now only remaps the host side of the local binding.
- `clearStaleOverride` no longer writes in dry-run mode.
- Status-page auto-refresh is driven by `SPEND_MONITOR_POLL_SECONDS` instead of a hardcoded 30s.
- Docstrings corrected: the freeze is held by per-poll re-zeroing, not by disabling auto-refill (LibreChat's per-request config-sync reverts that flag).
- Docs/env note that `setup-env.ts` auto-escapes `$` in `SPEND_MONITOR_BASIC_AUTH`.

## Verification (local)
- `tsc --noEmit` clean.
- Integration test against a real MongoDB (21 checks): enforce/zero, idempotent re-zero, restore-to-original, dry-run writes nothing, `clearStaleOverride` respects dry-run, page renders with custom poll interval - all pass.
- Built the image with podman and smoke-tested `/health`, `/api/spend`, `/`; logs confirm the container receives `enforce=dry-run` and runs the dry-run path.
- `docker compose -f docker-compose.prod.yml config` renders `SPEND_MONITOR_ENFORCE` and `PORT: "3016"` into the service environment.