### PR TITLE
fix(librechat): run baked-in @librechat/agents in prod/dev, drop host mount

### DIFF
--- a/.cursor/rules/environment-variables.mdc
+++ b/.cursor/rules/environment-variables.mdc
@@ -17,7 +17,7 @@ The setup uses three example files that are merged during generation:
 - Variables in example files can use `${VAR_NAME}` expansions - `setup-env.ts` resolves them iteratively
 
 ## 2. Naming Patterns
-**Prefix Convention**: `{SERVICE}_` in UPPER_SNAKE_CASE (e.g., `N8N_`, `FIRECRAWL_`, `LIBRECHAT_`)
+**Prefix Convention**: `{SERVICE}_` in UPPER_SNAKE_CASE (e.g., `SPEND_MONITOR_`, `FIRECRAWL_`, `LIBRECHAT_`)
 
 **Common Patterns**:
 - Connection: `{SERVICE}_HOST`, `{SERVICE}_PORT`, `{SERVICE}_PROTOCOL`, `{SERVICE}_URI`, `{SERVICE}_URL`

--- a/dev/README.md
+++ b/dev/README.md
@@ -12,7 +12,6 @@ This project includes the following git submodules:
 - **dev/librechat-doc** - LibreChat documentation
 - **dev/firecrawl** - Firecrawl web scraping service
 - **dev/searxng** - SearXNG metasearch engine (reference only - uses official Docker image)
-- **dev/n8n** - n8n workflow automation platform
 - **dev/open-streetmap-mcp** - OpenStreetMap MCP server (fork with HTTP transport support)
 - **dev/db-timetable-mcp** - Deutsche Bahn Timetable MCP server
 - **dev/stackoverflow-mcp** - Stack Overflow MCP server

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,14 +50,10 @@ services:
   api:
     extends: { file: docker-compose.librechat.yml, service: api }
     container_name: ${STACK_NAME:-prod}-librechat
-    # Use pre-built image from registry (built by GitHub Actions)
+    # Pre-built registry image (GitHub Actions). Our @librechat/agents fork (vision
+    # gating, custom reranker) is baked into this image by the CI build
+    # (.github/dockerfiles/librechat-with-agents.Dockerfile), so no host mount is needed.
     image: ghcr.io/faktenforum/librechat:dev
-    # Override the image's npm @librechat/agents with our built fork (vision gating,
-    # custom reranker). PREREQUISITE on the deploy host: submodules cloned recursively
-    # AND the fork built (`npm run build:dev`). An empty/unbuilt dev/agents makes the
-    # package empty and LibreChat will fail to start. See docs/PORTAINER-CONFIG.md.
-    volumes:
-      - ./dev/agents:/app/node_modules/@librechat/agents
     depends_on:
       librechat-init:
         condition: service_completed_successfully

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,16 +40,10 @@ services:
   api:
     extends: { file: docker-compose.librechat.yml, service: api }
     container_name: ${STACK_NAME:-prod}-librechat
-    # Use pre-built image from registry (built by GitHub Actions)
+    # Pre-built registry image (GitHub Actions). Our @librechat/agents fork (vision
+    # gating, custom reranker) is baked into this image by the CI build
+    # (.github/dockerfiles/librechat-with-agents.Dockerfile), so no host mount is needed.
     image: ghcr.io/faktenforum/librechat:latest
-    # Override the image's npm @librechat/agents with our built fork (vision gating,
-    # custom reranker). The registry image ships upstream @librechat/agents; this mount
-    # makes our customizations effective in prod.
-    # PREREQUISITE on the deploy host: submodules cloned recursively AND the fork built
-    # (`npm run build:dev`). An empty/unbuilt dev/agents makes the package empty and
-    # LibreChat will fail to start. See docs/PORTAINER-CONFIG.md.
-    volumes:
-      - ./dev/agents:/app/node_modules/@librechat/agents
     depends_on:
       librechat-init:
         condition: service_completed_successfully

--- a/docs/PORTAINER-CONFIG.md
+++ b/docs/PORTAINER-CONFIG.md
@@ -74,12 +74,11 @@ When changes are pushed to the repository, Portainer automatically pulls the lat
 
 ### Agents fork (prod/dev)
 
-`docker-compose.prod.yml` and `docker-compose.dev.yml` mount our `@librechat/agents` fork over the registry image's npm copy (`./dev/agents:/app/node_modules/@librechat/agents`) so the fork's customizations (vision gating, custom reranker) take effect. Two host prerequisites, or LibreChat will fail to start with an empty `@librechat/agents`:
+Our `@librechat/agents` fork (vision gating, custom reranker) is baked into the `ghcr.io/faktenforum/librechat` image at build time. CI (`.github/workflows/build-librechat.yml` + `.github/dockerfiles/librechat-with-agents.Dockerfile`) overlays the fork's compiled `dist` onto the base image. Prod and dev run that image directly - no host mount, no recursive submodule clone or fork build needed on the deploy host.
 
-1. Clone submodules recursively (Portainer: enable recursive/submodule clone for the stack repo).
-2. Build the fork before deploy: `npm run build:dev` (runs `build-dev-submodules.sh`, which builds `dev/agents`). The mount needs `dev/agents/dist`.
+To ship a fork change: edit `dev/agents`, push, let CI rebuild and publish the image, then **Pull and redeploy** the stack.
 
-Alternative (more robust for the registry-image model): bake the built fork into the librechat image in CI instead of mounting it. Tracked as a follow-up.
+The overlay copies only the fork's `dist` and `package.json`; its runtime dependencies come from the base image's `npm ci` of the same `@librechat/agents` version pinned in `dev/librechat/package-lock.json`. Keep the fork dependency-compatible with that version - a fork that adds or bumps a runtime dependency upstream does not declare will be missing at runtime (`MODULE_NOT_FOUND`).
 
 ## Data Safety
 


### PR DESCRIPTION
## What

prod/dev `api` service bind-mounted the host's `./dev/agents` over `/app/node_modules/@librechat/agents`. On the Portainer host that directory is empty (submodules aren't cloned/built there), so the mount **shadowed** the `@librechat/agents` that the CI build already bakes into `ghcr.io/faktenforum/librechat`. LibreChat crashed at startup:

```
Error: Cannot find module '@librechat/agents'
  code: 'MODULE_NOT_FOUND'
  requireStack: [ '/app/packages/api/dist/index.cjs', '/app/api/server/index.js' ]
```

## Why this is the right fix

The mount was a stopgap from #34, whose own message noted the "bake the fork into the CI image" alternative as a follow-up. That follow-up is in place: `.github/workflows/build-librechat.yml` builds `dev/agents` and `.github/dockerfiles/librechat-with-agents.Dockerfile` overlays its compiled `dist` onto the base image. So the registry image already carries our fork (vision gating, custom reranker) - the prod/dev mount is redundant and actively breaks startup. This also brings the compose set in line with `.cursor/rules/build-deploy-fork-images.mdc` (prod/dev = registry image only) and the no-bind-mounts-in-prod rule.

`local.yml` / `local-dev.yml` keep the mount on purpose: they build the base image from `dev/librechat/Dockerfile` without the agents overlay, so they need the host's built `dev/agents`.

## Verified locally (podman, against the real `:latest` image)

- empty mount over `/app/node_modules/@librechat/agents` → reproduces the exact `MODULE_NOT_FOUND` crash
- no mount → `require.resolve('@librechat/agents')` → `/app/node_modules/@librechat/agents/dist/cjs/main.cjs` (our fork v3.2.38, `dist/{cjs,esm,types}` + transitive deps present)
- `docker compose -f docker-compose.{prod,dev}.yml config` → no agents mount; the 4 base volumes (images, uploads, logs, librechat-config) are preserved via `extends`

Reviewed by a 3-lens adversarial pass (regression-safety, completeness, n8n/doc-accuracy): all safe-to-merge.

## Also

- `docs/PORTAINER-CONFIG.md`: drop the obsolete "clone submodules recursively + `npm run build:dev` on host" prerequisite; document the baked-image flow and the fork dependency-compatibility constraint.
- Remove stale n8n references (`dev/README.md` submodule bullet, `N8N_` env example). n8n was removed from the stack earlier; only doc mentions remained.

## Deploy

No image rebuild required (compose files aren't in the build workflow's path filter; the existing `:latest`/`:dev` images already contain the fork). **Pull and redeploy** the stack.