### PR TITLE
fix(librechat): correct glm-5.2 context/output, scaleway output caps, drop unusable voxtral

### DIFF
--- a/packages/librechat-init/config/agents.yaml
+++ b/packages/librechat-init/config/agents.yaml
@@ -231,7 +231,7 @@ agents:
     model_parameters:
       temperature: 0.5
       top_p: 0.9
-      maxContextTokens: 128000   # GLM 5.2; Scaleway served context not yet documented (conservative)
+      maxContextTokens: 262144   # GLM 5.2 (Scaleway: 262144 context, 16384 output cap)
     tools:
       - web_search
     mcpServers:
@@ -429,7 +429,7 @@ agents:
     model_parameters:
       temperature: 0.4
       top_p: 0.9
-      maxContextTokens: 128000   # GLM 5.2; Scaleway served context not yet documented (conservative)
+      maxContextTokens: 262144   # GLM 5.2 (Scaleway: 262144 context, 16384 output cap)
     tools:
       - web_search
     mcpServers:
@@ -685,7 +685,7 @@ agents:
     model_parameters:
       temperature: 0.4
       top_p: 0.9
-      maxContextTokens: 128000   # GLM 5.2; Scaleway served context not yet documented (conservative)
+      maxContextTokens: 262144   # GLM 5.2 (Scaleway: 262144 context, 16384 output cap)
     tools: []
     mcpServers:
       - linux
@@ -944,7 +944,7 @@ agents:
     model_parameters:
       temperature: 0.4
       top_p: 0.9
-      maxContextTokens: 128000   # GLM 5.2; Scaleway served context not yet documented (conservative)
+      maxContextTokens: 262144   # GLM 5.2 (Scaleway: 262144 context, 16384 output cap)
     tools:
       - web_search
     mcpServers:
@@ -1048,7 +1048,7 @@ agents:
     model_parameters:
       temperature: 0.5
       top_p: 0.9
-      maxContextTokens: 128000   # GLM 5.2; Scaleway served context not yet documented (conservative)
+      maxContextTokens: 262144   # GLM 5.2 (Scaleway: 262144 context, 16384 output cap)
     mcpServers:
       - linux
     mcpTools:

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -197,7 +197,7 @@ endpoints:
         qwen3.5-397b-a17b:                   { prompt: 0.65, completion: 3.89, context: 250000 }
         qwen3.6-35b-a3b:                     { prompt: 0.27, completion: 1.62, context: 256000 }
         mistral-medium-3.5-128b:             { prompt: 1.62, completion: 8.10, context: 256000 }
-        glm-5.2:                             { prompt: 1.94, completion: 5.94, context: 128000 }
+        glm-5.2:                             { prompt: 1.94, completion: 5.94, context: 262144 }
         qwen3-embedding-8b:                  { prompt: 0.11, completion: 0, context: 32000 }
         bge-multilingual-gemma2:             { prompt: 0.11, completion: 0, context: 8000 }
       titleConvo: true
@@ -564,7 +564,7 @@ modelSpecs:
     # Token limits: Scaleway Generative APIs + Managed Inference model catalog (Oct 2025)
     - name: "scaleway-glm-5.2"
       label: "GLM 5.2"
-      description: "Starkes Reasoning- und Coding-Modell (Z.AI, MoE). Eines der besten Open-Weight-Modelle, europäisch gehostet (Scaleway). Text und Code. Scaleway-Kontext noch nicht final dokumentiert; konservativ 128K. Open Weights (Z.AI)."
+      description: "Starkes Reasoning- und Coding-Modell (Z.AI, MoE). Eines der besten Open-Weight-Modelle, europäisch gehostet (Scaleway). 256K Context, 16K Output. Text und Code. Open Weights (Z.AI)."
       group: "Europa & Open Source"
       groupIcon: "/images/group-europa.svg"
       order: 0
@@ -572,8 +572,8 @@ modelSpecs:
         endpoint: "Scaleway"
         endpointType: "custom"
         model: "glm-5.2"
-        maxContextTokens: 128000
-        maxOutputTokens: 32000
+        maxContextTokens: 262144
+        maxOutputTokens: 16384
 
     - name: "scaleway-devstral-2-123b"
       label: "Devstral 2 123B"
@@ -587,7 +587,7 @@ modelSpecs:
         endpointType: "custom"
         model: "devstral-2-123b-instruct-2512"
         maxContextTokens: 200000
-        maxOutputTokens: 8192
+        maxOutputTokens: 16384
 
     - name: "scaleway-gemma-4-26b"
       label: "Gemma 4 26B"
@@ -600,7 +600,7 @@ modelSpecs:
         endpointType: "custom"
         model: "gemma-4-26b-a4b-it"
         maxContextTokens: 256000
-        maxOutputTokens: 32000
+        maxOutputTokens: 32768
 
     - name: "scaleway-gpt-oss-120b"
       label: "GPT-OSS 120B"
@@ -612,7 +612,7 @@ modelSpecs:
         endpointType: "custom"
         model: "gpt-oss-120b"
         maxContextTokens: 128000
-        maxOutputTokens: 8192
+        maxOutputTokens: 32768
 
     - name: "scaleway-holo2-30b"
       label: "Holo2 30B"
@@ -637,7 +637,7 @@ modelSpecs:
         endpointType: "custom"
         model: "llama-3.3-70b-instruct"
         maxContextTokens: 100000   # Generative APIs; Managed Inference up to 128k (instance-dependent)
-        maxOutputTokens: 4096
+        maxOutputTokens: 16384
 
     - name: "scaleway-mistral-small-3.2"
       label: "Mistral Small 3.2 24B"
@@ -650,7 +650,7 @@ modelSpecs:
         endpointType: "custom"
         model: "mistral-small-3.2-24b-instruct-2506"
         maxContextTokens: 128000
-        maxOutputTokens: 8192
+        maxOutputTokens: 32768
 
     - name: "scaleway-pixtral-12b"
       label: "Pixtral 12B"
@@ -675,7 +675,7 @@ modelSpecs:
         endpointType: "custom"
         model: "qwen3-235b-a22b-instruct-2507"
         maxContextTokens: 250000
-        maxOutputTokens: 8192
+        maxOutputTokens: 16384
 
     - name: "scaleway-qwen3-coder-30b"
       label: "Qwen3 Coder 30B"
@@ -687,19 +687,7 @@ modelSpecs:
         endpointType: "custom"
         model: "qwen3-coder-30b-a3b-instruct"
         maxContextTokens: 128000
-        maxOutputTokens: 8192
-
-    - name: "scaleway-voxtral-small-24b"
-      label: "Voxtral Small 24B"
-      description: "Chat- und Audio-Modell (Mistral). 32K Context, 8K Output. Transkription und Verstehen von Audio (WAV, MP3), mehrsprachig. Apache-2.0 License. Zum Testen der Audio-Fähigkeiten."
-      group: "Europa & Open Source"
-      order: 10
-      preset:
-        endpoint: "Scaleway"
-        endpointType: "custom"
-        model: "voxtral-small-24b-2507"
-        maxContextTokens: 32000
-        maxOutputTokens: 8192
+        maxOutputTokens: 32768
 
     - name: "scaleway-qwen3.5-397b"
       label: "Qwen3.5 397B"
@@ -712,7 +700,7 @@ modelSpecs:
         endpointType: "custom"
         model: "qwen3.5-397b-a17b"
         maxContextTokens: 250000
-        maxOutputTokens: 16000
+        maxOutputTokens: 16384
 
     - name: "scaleway-qwen3.6-35b"
       label: "Qwen3.6 35B"
@@ -725,7 +713,7 @@ modelSpecs:
         endpointType: "custom"
         model: "qwen3.6-35b-a3b"
         maxContextTokens: 256000
-        maxOutputTokens: 32000
+        maxOutputTokens: 32768
 
     # ==========================================
     # Premium-Modelle (OpenRouter) – alphabetisch nach Label


### PR DESCRIPTION
Follow-up to #46 (which merged before these parameter corrections landed). All values verified against authoritative sources.

## GLM 5.2 — correct context + output
Probed Scaleway directly (the docs supported-models table still omits glm-5.2):
- **context = 262144** (256k) — was a conservative `128000`
- **output = 16384** (Scaleway hard cap: `max_completion_tokens is limited to 16384 for glm-5.2`) — the spec had `32000`, which **would 400 on direct model selection**

Applied to the spec, `tokenConfig`, and the 5 migrated agents (now `maxContextTokens: 262144`).

## Scaleway output caps — corrected to real per-model limits
Probed/confirmed via the API + docs table (`16k`=16384, `32k`=32768). Several were under-set and silently truncating output:

| model | was | now |
|---|---|---|
| devstral-2-123b, qwen3-235b | 8192 | 16384 |
| llama-3.3-70b | 4096 | 16384 |
| gpt-oss-120b, mistral-small-3.2, qwen3-coder-30b | 8192 | 32768 |
| gemma-4-26b, qwen3.6-35b | 32000 | 32768 |
| qwen3.5-397b | 16000 | 16384 |

(pixtral 4096 already correct; holo2 left at 8192 — see below.)

## Voxtral removed — audio unusable in our setup
LibreChat only emits `input_audio` to the model for **Google / VertexAI / OpenRouter** providers (`packages/api/src/files/encode/audio.ts` — there is no branch for a custom endpoint). On our Scaleway endpoint, audio never reaches the model; it only goes through STT (whisper). So Voxtral's audio understanding can't be used, and as a plain 24B text model it's redundant with mistral-small-3.2. Spec removed; `tokenConfig` kept so it still bills correctly if picked from the fetched list.

## OpenRouter — re-verified, no change
All OpenRouter spec context/output values checked against `/api/v1/models` (`context_length` + `top_provider.max_completion_tokens`); all within provider limits.

## Deploy
Redeploy the stack so `librechat-init` rewrites the config volume.