### PR TITLE
fix(librechat): correct stale model names and a dead agent reference

### DIFF
--- a/packages/librechat-init/config/agent-instructions/shared-agent-feedback-instructions.md
+++ b/packages/librechat-init/config/agent-instructions/shared-agent-feedback-instructions.md
@@ -2,7 +2,7 @@
 
 {{include:mcp-github-repo-default.md}}
 
-Role: Bug reporter & feature requester for chat interface. No GitHub or create_issue tools — you must hand off to Code Research for analysis, then GitHub Assistant creates the issue; never call create_issue or any GitHub tool yourself. Prefer the default Code Research; use Code Research (Claude Opus 4.8) only when the user emphasizes quality or when falling back after the default could not fulfill the task. Understand error (what happened, steps, expected vs actual, environment); 1–2 clarifying questions if needed. Do not hand back to Main Assistant for ambiguity; ask or interpret within your role.
+Role: Bug reporter & feature requester for chat interface. No GitHub or create_issue tools — you must hand off to Developer for analysis, then GitHub Assistant creates the issue; never call create_issue or any GitHub tool yourself. Prefer the default Developer; use Developer (Claude Opus 4.8) only when the user emphasizes quality or when falling back after the default could not fulfill the task. Understand error (what happened, steps, expected vs actual, environment); 1–2 clarifying questions if needed. Do not hand back to Main Assistant for ambiguity; ask or interpret within your role.
 
 WORKSPACE: Always use fixed workspace `feedback` for all bug reports and feature requests. This ensures all agents know where to find the plan and issue details.
 
@@ -23,20 +23,20 @@ WORKFLOW:
    - Check if plan exists: `get_workspaces("feedback")`
    - If old plan exists and is completed/obsolete: overwrite with new plan
    - Plan structure:
-     - Task 1 (in_progress): "Research bug: search GitHub issues for duplicates in faktenforum/ai-chat-interface, analyze relevant code, improve issue details if needed" → Code Research (default; use Code Research (Claude Opus 4.8) if user emphasizes quality or if default failed)
+     - Task 1 (in_progress): "Research bug: search GitHub issues for duplicates in faktenforum/ai-chat-interface, analyze relevant code, improve issue details if needed" → Developer (default; use Developer (Claude Opus 4.8) if user emphasizes quality or if default failed)
      - Task 2 (pending): "Create GitHub issue with researched details" → GitHub Assistant
        - Instructions for GitHub Assistant: "workspace: feedback — call `get_workspaces('feedback')` to read issue details from the plan, then create the issue via `create_issue_mcp_github(owner='faktenforum', repo='ai-chat-interface', title=..., body=...)` using title and body from the plan (English)."
      - Task 3 (pending, optional): "Implement fix" → Code Assistant (only if user explicitly wants fix, not just reporting)
        - Instructions for Code Assistant: "workspace: feedback — call `get_workspaces('feedback')` to read bug details from the plan. User wants to fix the reported bug in faktenforum/ai-chat-interface. Summarize error, steps to reproduce, expected vs actual behavior, and what needs to be fixed (debug, implement fix). Pass workspace name and relevant context from the plan to the appropriate developer specialist."
-   - Embed full structured issue (title, body, label) in the plan so Code Research has all context
+   - Embed full structured issue (title, body, label) in the plan so Developer has all context
 
-4. **Hand off to Code Research**: Prefer default Code Research; use Code Research (Claude Opus 4.8) only when the user emphasizes quality or when falling back after the default failed. Transfer with workspace `feedback` in instructions. Code Research will read the plan, perform research, then hand off to GitHub Assistant using the instructions specified in Task 2 of the plan.
+4. **Hand off to Developer**: Prefer default Developer; use Developer (Claude Opus 4.8) only when the user emphasizes quality or when falling back after the default failed. Transfer with workspace `feedback` in instructions. Developer will read the plan, perform research, then hand off to GitHub Assistant using the instructions specified in Task 2 of the plan.
 
 {{include:workflow-multi-agent.md}}
 
 AUTOMATIC FEATURE REQUESTS: When an agent fails due to missing system dependencies (e.g. data analysis, document creation, conversion, development tasks report missing libs/tools), automatically create a feature request. Title: "Missing system dependency: [tool/lib name]". Body: agent name, task attempted, missing dependency, error message, suggested fix (e.g. "Add to Dockerfile: apt-get install [package]" or "Install via uv: uv tool install [package]").
 
-If user wants to fix the bug immediately (not just report): add Task 3 to plan and hand off to Code Assistant after Code Research completes research.
+If user wants to fix the bug immediately (not just report): add Task 3 to plan and hand off to Code Assistant after Developer completes research.
 
 {{include:conventions-when-unclear.md}} Handoff issue text: English only.
 

--- a/packages/librechat-init/config/agents.yaml
+++ b/packages/librechat-init/config/agents.yaml
@@ -166,7 +166,7 @@ agents:
 
   - id: shared-agent-code-assistant
     name: Code Assistant
-    description: Routes developer requests to the appropriate specialist – Code Research, implementation, refactoring, GitHub, Code Review.
+    description: Routes developer requests to the appropriate specialist - implementation, refactoring, GitHub, Code Review.
     instructionsFile: shared-agent-code-assistant-instructions.md
     provider: Scaleway
     model: devstral-2-123b-instruct-2512
@@ -200,7 +200,7 @@ agents:
         description: "Transfer to Code Refactorer (default, OpenSource). Prefer this unless the user emphasizes quality or a previous attempt with the default failed."
         prompt: "Describe what code needs refactoring, the goals (readability, performance, structure), and the workspace/repo context"
       - agent: shared-agent-code-refactorer-quality
-        description: "Transfer to Code Refactorer (Gemini 3 Pro Preview) when the user explicitly asks for higher quality or when the default Code Refactorer could not fulfill the task."
+        description: "Transfer to Code Refactorer (Gemini 3.1 Pro Preview) when the user explicitly asks for higher quality or when the default Code Refactorer could not fulfill the task."
         prompt: "Describe what code needs refactoring, the goals (readability, performance, structure), and the workspace/repo context"
       - agent: shared-agent-github
         description: "Transfer to GitHub assistant for PR creation, issue management, reviews posting, and repo operations"
@@ -209,7 +209,7 @@ agents:
         description: "Transfer to Code Reviewer (default, OpenSource). Prefer this unless the user emphasizes quality or a previous attempt with the default failed."
         prompt: "Provide the PR URL and any specific review focus areas"
       - agent: shared-agent-code-reviewer-quality
-        description: "Transfer to Code Reviewer (Gemini 3 Pro Preview) when the user explicitly asks for higher quality or when the default Code Reviewer could not fulfill the task."
+        description: "Transfer to Code Reviewer (Gemini 3.1 Pro Preview) when the user explicitly asks for higher quality or when the default Code Reviewer could not fulfill the task."
         prompt: "Provide the PR URL and any specific review focus areas"
       - agent: shared-agent-main-assistant
         description: "Return to Main Assistant only for non-development tasks. Do not hand back merely because the request is ambiguous; then ask one short clarifying question or handle within your dev role."
@@ -312,7 +312,7 @@ agents:
         description: "Transfer to Code Refactorer (default, OpenSource). Prefer this unless the user emphasizes quality or a previous attempt with the default failed."
         prompt: "Summarize what was implemented and which parts should be refactored (readability, structure, tests, style)"
       - agent: shared-agent-code-refactorer-quality
-        description: "Transfer to Code Refactorer (Gemini 3 Pro Preview) when the user explicitly asks for higher quality or when the default Code Refactorer could not fulfill the task."
+        description: "Transfer to Code Refactorer (Gemini 3.1 Pro Preview) when the user explicitly asks for higher quality or when the default Code Refactorer could not fulfill the task."
         prompt: "Summarize what was implemented and which parts should be refactored (readability, structure, tests, style)"
     # Dev: implement/fix, many file and terminal ops
     recursion_limit: 120
@@ -412,7 +412,7 @@ agents:
         description: "Transfer to Code Refactorer (default, OpenSource). Prefer this unless the user emphasizes quality or a previous attempt with the default failed."
         prompt: "Summarize what was implemented and which parts should be refactored (readability, structure, tests, style)"
       - agent: shared-agent-code-refactorer-quality
-        description: "Transfer to Code Refactorer (Gemini 3 Pro Preview) when the user explicitly asks for higher quality or when the default Code Refactorer could not fulfill the task."
+        description: "Transfer to Code Refactorer (Gemini 3.1 Pro Preview) when the user explicitly asks for higher quality or when the default Code Refactorer could not fulfill the task."
         prompt: "Summarize what was implemented and which parts should be refactored (readability, structure, tests, style)"
     recursion_limit: 80
     isCollaborative: true
@@ -488,7 +488,7 @@ agents:
         description: "Transfer to Code Reviewer (default, OpenSource). Prefer this unless the user emphasizes quality or a previous attempt with the default failed."
         prompt: "Include the workspace name you are using, the PR URL, and that the user wants the review comments read and the mentioned issues fixed"
       - agent: shared-agent-code-reviewer-quality
-        description: "Transfer to Code Reviewer (Gemini 3 Pro Preview) when the user explicitly asks for higher quality or when the default Code Reviewer could not fulfill the task."
+        description: "Transfer to Code Reviewer (Gemini 3.1 Pro Preview) when the user explicitly asks for higher quality or when the default Code Reviewer could not fulfill the task."
         prompt: "Include the workspace name you are using, the PR URL, and that the user wants the review comments read and the mentioned issues fixed"
     # Dev: refactor, tests, many file reads
     recursion_limit: 100
@@ -566,7 +566,7 @@ agents:
         description: "Transfer to Code Reviewer (default, OpenSource). Prefer this unless the user emphasizes quality or a previous attempt with the default failed."
         prompt: "Include the workspace name you are using, the PR URL, and that the user wants the review comments read and the mentioned issues fixed"
       - agent: shared-agent-code-reviewer-quality
-        description: "Transfer to Code Reviewer (Gemini 3 Pro Preview) when the user explicitly asks for higher quality or when the default Code Reviewer could not fulfill the task."
+        description: "Transfer to Code Reviewer (Gemini 3.1 Pro Preview) when the user explicitly asks for higher quality or when the default Code Reviewer could not fulfill the task."
         prompt: "Include the workspace name you are using, the PR URL, and that the user wants the review comments read and the mentioned issues fixed"
     recursion_limit: 80
     isCollaborative: true
@@ -661,13 +661,13 @@ agents:
         description: "Transfer to Code Refactorer (default, OpenSource). Prefer this unless the user emphasizes quality or a previous attempt with the default failed."
         prompt: "Describe the code that needs refactoring"
       - agent: shared-agent-code-refactorer-quality
-        description: "Transfer to Code Refactorer (Gemini 3 Pro Preview) when the user explicitly asks for higher quality or when the default Code Refactorer could not fulfill the task."
+        description: "Transfer to Code Refactorer (Gemini 3.1 Pro Preview) when the user explicitly asks for higher quality or when the default Code Refactorer could not fulfill the task."
         prompt: "Describe the code that needs refactoring"
       - agent: shared-agent-code-reviewer
         description: "Transfer to Code Reviewer (default, OpenSource). Prefer this unless the user emphasizes quality or a previous attempt with the default failed."
         prompt: "Provide the PR URL and context for review"
       - agent: shared-agent-code-reviewer-quality
-        description: "Transfer to Code Reviewer (Gemini 3 Pro Preview) when the user explicitly asks for higher quality or when the default Code Reviewer could not fulfill the task."
+        description: "Transfer to Code Reviewer (Gemini 3.1 Pro Preview) when the user explicitly asks for higher quality or when the default Code Reviewer could not fulfill the task."
         prompt: "Provide the PR URL and context for review"
     # Dev: GitHub API + git, many file/API ops
     recursion_limit: 100

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -409,7 +409,7 @@ modelSpecs:
 
     - name: "agent-code-assistant"
       label: "Code Assistant"
-      description: "Routes developer requests to the appropriate specialist – Code Research, implementation, refactoring, GitHub, Code Review."
+      description: "Routes developer requests to the appropriate specialist - implementation, refactoring, GitHub, Code Review."
       group: "Assistants"
       order: 5
       preset:
@@ -448,8 +448,8 @@ modelSpecs:
         agent_id: "shared-agent-code-refactorer"
 
     - name: "agent-code-refactorer-quality"
-      label: "Code Refactorer (Gemini 3 Pro Preview)"
-      description: "Code Refactorer with OpenRouter Gemini 3 Pro – for higher quality or fallback when the default variant is insufficient."
+      label: "Code Refactorer (Gemini 3.1 Pro Preview)"
+      description: "Code Refactorer with OpenRouter Gemini 3.1 Pro – for higher quality or fallback when the default variant is insufficient."
       group: "Assistants"
       order: 11
       preset:
@@ -468,8 +468,8 @@ modelSpecs:
         agent_id: "shared-agent-code-reviewer"
 
     - name: "agent-code-reviewer-quality"
-      label: "Code Reviewer (Gemini 3 Pro Preview)"
-      description: "Code Reviewer with OpenRouter Gemini 3 Pro – for higher quality or fallback when the default variant is insufficient."
+      label: "Code Reviewer (Gemini 3.1 Pro Preview)"
+      description: "Code Reviewer with OpenRouter Gemini 3.1 Pro – for higher quality or fallback when the default variant is insufficient."
       group: "Assistants"
       order: 13
       preset:

--- a/packages/librechat-init/config/prompts.yaml
+++ b/packages/librechat-init/config/prompts.yaml
@@ -28,10 +28,10 @@ prompts:
     prompt: |
       Please review {{Github Pull Request URL}} and publish it as a comment in the PR.
       
-      **Important**: Use the Quality developer agents (Code Reviewer with Gemini 3 Pro Preview) for higher quality and more detailed analysis. This variant uses more expensive but more powerful models.
+      **Important**: Use the Quality developer agents (Code Reviewer with Gemini 3.1 Pro Preview) for higher quality and more detailed analysis. This variant uses more expensive but more powerful models.
     command: review-github-pr-quality
     category: code
-    oneliner: Reviews a GitHub Pull Request with Quality agents (Gemini 3 Pro Preview) for higher quality and more detailed analysis.
+    oneliner: Reviews a GitHub Pull Request with Quality agents (Gemini 3.1 Pro Preview) for higher quality and more detailed analysis.
     sharing:
       public:
         enabled: true
@@ -60,18 +60,18 @@ prompts:
       Process the GitHub Pull Request {{Github Pull Request URL}} completely.
 
       **Important**: Use the Quality developer agents for higher quality:
-      - Code Reviewer (Gemini 3 Pro Preview) for detailed reviews
-      - Code Refactorer (Gemini 3 Pro Preview) for refactoring
+      - Code Reviewer (Gemini 3.1 Pro Preview) for detailed reviews
+      - Code Refactorer (Gemini 3.1 Pro Preview) for refactoring
       - Developer (Claude Opus 4.8) for implementations
       
       This variant uses more expensive but more powerful models for better results.
 
       ## Process
 
-      1. **Review**: Analyze the PR (Code, Tests, Docs) with Code Reviewer (Gemini 3 Pro Preview). Identify improvement points.
+      1. **Review**: Analyze the PR (Code, Tests, Docs) with Code Reviewer (Gemini 3.1 Pro Preview). Identify improvement points.
       2. **Refactor Plan**: Create a prioritized list of changes.
       3. **Workspace**: If a Linux workspace exists for this PR – check if it is current and reusable; otherwise reset and create new.
-      4. **Implementation**: Delegate each task to the Quality experts (Code Refactorer with Gemini 3 Pro Preview, Developer with Claude Opus 4.8). Each expert completes their task and hands off to the next, until all points are completed.
+      4. **Implementation**: Delegate each task to the Quality experts (Code Refactorer with Gemini 3.1 Pro Preview, Developer with Claude Opus 4.8). Each expert completes their task and hands off to the next, until all points are completed.
       5. **Completion**: Push the changes to the PR branch. Leave a PR comment summarizing the review and the improvements made.
 
       ## Rules
@@ -80,7 +80,7 @@ prompts:
       - The final PR comment must clearly document review results and change list.
     command: refactor-github-pr-quality
     category: code
-    oneliner: Reviews a GitHub PR with Quality agents (Gemini 3 Pro Preview, Claude Opus 4.8), implements improvements and pushes them to the branch.
+    oneliner: Reviews a GitHub PR with Quality agents (Gemini 3.1 Pro Preview, Claude Opus 4.8), implements improvements and pushes them to the branch.
     sharing:
       public:
         enabled: true
@@ -149,7 +149,7 @@ prompts:
       Create a high-quality image that matches all these specifications. Focus on composition, detail, and artistic coherence.
     command: generate-image
     category: misc
-    oneliner: Generates an image with customizable style, aspect ratio, quality, lighting, mood, and color scheme parameters.
+    oneliner: Generates an image with customizable style, quality, lighting, mood, and color scheme parameters.
     sharing:
       public:
         enabled: true


### PR DESCRIPTION
Pure correctness fixes to the LibreChat config + instructions (no behavior change beyond fixing demonstrable drift). All bake into the librechat-init image.

## Model name drift
The two Quality coding agents run `google/gemini-3.1-pro-preview`, and their agent `name:` fields already say **Gemini 3.1 Pro Preview** - but the modelSpec labels/descriptions and ~15 prompt/handoff strings still said **Gemini 3 Pro Preview** (and two said bare **Gemini 3 Pro**). Users saw one version in the selector and another in the prose. Renamed `Gemini 3 Pro` -> `Gemini 3.1 Pro` across:
- `prompts.yaml` (7)
- `agents.yaml` handoff descriptions (8)
- `librechat.yaml` modelSpecs labels + descriptions (4)

## Dead agent reference (real routing bug)
The **Feedback agent** instructions repeatedly told the model to hand off to a **Code Research** agent, and the **Code Assistant** description listed *Code Research* as a specialist. No such agent exists - the feedback agent's actual handoff targets are `shared-agent-developer` / `shared-agent-developer-quality` ("Developer" / "Developer (Claude Opus 4.8)"). The model was told to transfer to a target not in its handoff list. Renamed `Code Research` -> `Developer` and dropped the ghost from the Code Assistant specialist list.

## Prompt over-promise
The Image Generation one-liner advertised an `aspect ratio` parameter the prompt body never defined; removed it so the variable picker matches.

## Verified
- No bare `Gemini 3 Pro` or `Code Research` strings remain in config.
- All three YAML files parse.
- Agent `name:` fields and `maxContextTokens` comments were already correct and untouched.