### PR TITLE
docs: fix stale dev-agent models, dead agent reference, and index/link gaps

### DIFF
--- a/docs/DEVELOPER_AGENTS.md
+++ b/docs/DEVELOPER_AGENTS.md
@@ -19,18 +19,18 @@ Specialists do **not** hand off back to the router; they hand off to Main Assist
 
 ## Agents
 
-Each of the three Code specialists (Developer, Code Refactorer, Code Reviewer) has two variants: a **default** (OpenSource, Scaleway devstral) and a **quality** variant (OpenRouter, name includes model). Use the default first; use the quality variant when the user explicitly emphasizes quality or when the default could not fulfill the task (fallback).
+Each of the three Code specialists (Developer, Code Refactorer, Code Reviewer) has two variants: a **default** (OpenSource, Scaleway glm-5.2) and a **quality** variant (OpenRouter, name includes model). Use the default first; use the quality variant when the user explicitly emphasizes quality or when the default could not fulfill the task (fallback).
 
 | Agent | ID | Provider | Model | Tools | Role |
 |-------|----|----------|-------|-------|------|
 | **Code Assistant** | `shared-agent-code-assistant` | Scaleway | devstral-2-123b | list_workspaces, get_workspace_status (MCP Linux) | Route to specialist; uses tools only to pass explicit workspace name in handoff. |
-| **Developer** (default) | `shared-agent-developer` | Scaleway | devstral-2-123b | 18 (Linux full, web_search) | Implement, fix bugs. |
-| **Developer (Claude Opus 4.6)** (quality) | `shared-agent-developer-quality` | OpenRouter | anthropic/claude-opus-4.6 | same | Same role; use when user wants higher quality or default failed. |
-| **Code Refactorer** (default) | `shared-agent-code-refactorer` | Scaleway | devstral-2-123b | 18 (Linux full, web_search) | Refactor, polish, restructure. |
-| **Code Refactorer (Gemini 3 Pro Preview)** (quality) | `shared-agent-code-refactorer-quality` | OpenRouter | google/gemini-3-pro-preview | same | Same role; use when user wants higher quality or default failed. |
+| **Developer** (default) | `shared-agent-developer` | Scaleway | glm-5.2 | 18 (Linux full, web_search) | Implement, fix bugs. |
+| **Developer (Claude Opus 4.8)** (quality) | `shared-agent-developer-quality` | OpenRouter | anthropic/claude-opus-4.8 | same | Same role; use when user wants higher quality or default failed. |
+| **Code Refactorer** (default) | `shared-agent-code-refactorer` | Scaleway | glm-5.2 | 18 (Linux full, web_search) | Refactor, polish, restructure. |
+| **Code Refactorer (Gemini 3.1 Pro Preview)** (quality) | `shared-agent-code-refactorer-quality` | OpenRouter | google/gemini-3.1-pro-preview | same | Same role; use when user wants higher quality or default failed. |
 | **GitHub Assistant** | `shared-agent-github` | Scaleway | devstral-2-123b | GitHub (read+write), Linux minimal | PRs, issues, releases; create/update/merge PR, review, file/repo ops. See [GitHub tools](#github-tools). |
-| **Code Reviewer** (default) | `shared-agent-code-reviewer` | Scaleway | devstral-2-123b | ~18 (Linux subset, GitHub read) | Single entry for PR reviews: clone repo, analyze via Linux MCP, produce review; hand off to GitHub Assistant to post on GitHub when the user requests it. |
-| **Code Reviewer (Gemini 3 Pro Preview)** (quality) | `shared-agent-code-reviewer-quality` | OpenRouter | google/gemini-3-pro-preview | same | Same role; use when user wants higher quality or default failed. |
+| **Code Reviewer** (default) | `shared-agent-code-reviewer` | Scaleway | glm-5.2 | ~18 (Linux subset, GitHub read) | Single entry for PR reviews: clone repo, analyze via Linux MCP, produce review; hand off to GitHub Assistant to post on GitHub when the user requests it. |
+| **Code Reviewer (Gemini 3.1 Pro Preview)** (quality) | `shared-agent-code-reviewer-quality` | OpenRouter | google/gemini-3.1-pro-preview | same | Same role; use when user wants higher quality or default failed. |
 
 ## Chains
 
@@ -38,7 +38,7 @@ No automatic chains. All transitions between specialists are via explicit handof
 
 ## Handoffs
 
-Each specialist can hand off to Main Assistant and to 2–3 relevant specialists (e.g. Developer → Code Research, GitHub Assistant). Specialists do **not** hand off back to Code Assistant. Handoff: call the transfer tool (runtime name `lc_transfer_to_<api_id>`), pass context in the **instructions** parameter. Main Assistant has no GitHub tools; for bug reports only hand off to Feedback Assistant.
+Each specialist can hand off to Main Assistant and to 2–3 relevant specialists (e.g. Developer → Code Refactorer, GitHub Assistant). Specialists do **not** hand off back to Code Assistant. Handoff: call the transfer tool (runtime name `lc_transfer_to_<api_id>`), pass context in the **instructions** parameter. Main Assistant has no GitHub tools; for bug reports only hand off to Feedback Assistant.
 
 For the three Code specialists (Developer, Code Refactorer, Code Reviewer), handoffs include **both** the default and the quality variant. The handoff **description** in `agents.yaml` guides the LLM: prefer the default; use the quality variant only when the user explicitly emphasizes quality or when the default could not fulfill the task.
 
@@ -55,7 +55,7 @@ For the three Code specialists (Developer, Code Refactorer, Code Reviewer), hand
 2. **Code Reviewer**: `pull_request_read` → head/base ref and repo URL; `create_workspace` (git_url, branch = head ref) → in workspace: `git fetch origin <base_ref>`, `git diff origin/<base_ref>...HEAD`; `read_workspace_file` for changed files and context → analyze → structured review (summary + optional inline comments).
 3. To post on GitHub: **Code Reviewer** hands off via transfer tool with review body and inline comments; **GitHub Assistant** uses `create_review` or `pull_request_review_write`. If using `pull_request_review_write` with method `create`, the assistant must then call it again with method `submit_pending` so the review is published; otherwise only a pending (draft) review exists and nothing appears on the PR.
 
-Optional handoffs: Code Reviewer → Code Research (codebase context) or → Developer (fix issues).
+Optional handoffs: Code Reviewer → Developer (fix issues).
 
 **GitHub content:** GitHub Assistant posts all review bodies, inline comments, and issue/PR text in **English** (per agent instructions).
 
@@ -65,7 +65,7 @@ Optional handoffs: Code Reviewer → Code Research (codebase context) or → Dev
 
 ## GitHub tools
 
-Write tools are **only on GitHub Assistant**; Code Research and Code Reviewer have read-only GitHub tools. Code Reviewer hands off to GitHub Assistant to post reviews.
+Write tools are **only on GitHub Assistant**; Code Reviewer has read-only GitHub tools. Code Reviewer hands off to GitHub Assistant to post reviews.
 
 GitHub Assistant’s tools in `agents.yaml` (suffix `_mcp_github`):
 
@@ -80,7 +80,7 @@ Only tools the GitHub MCP server actually provides are exposed; unknown names in
 
 ## Troubleshooting
 
-**"empty_messages" / "Message pruning removed all messages"** when using Scaleway (or other custom endpoints) for dev agents: Custom endpoints without `endpointTokenConfig` get a **18K context fallback**. Long chains (Main Assistant → Router → Code Refactorer/Code Reviewer plus PR/commit data) exceed that; pruning then removes all messages. **Fix:** set `maxContextTokens` in each agent’s `model_parameters` in `agents.yaml` to the model’s real context (e.g. `200000` for Devstral 2 123B). Re-run the librechat-init after any change to `agents.yaml` so the DB receives the updated `model_parameters`; otherwise the runtime keeps using the 18K fallback. For very large PRs, use the quality variant (e.g. Code Reviewer with Gemini 3 Pro Preview, 1M context). See [AGENTS_CONTEXT_LIMIT](wip/AGENTS_CONTEXT_LIMIT.md) for the init/pruning flow.
+**"empty_messages" / "Message pruning removed all messages"** when using Scaleway (or other custom endpoints) for dev agents: Custom endpoints without `endpointTokenConfig` get a **18K context fallback**. Long chains (Main Assistant → Router → Code Refactorer/Code Reviewer plus PR/commit data) exceed that; pruning then removes all messages. **Fix:** set `maxContextTokens` in each agent’s `model_parameters` in `agents.yaml` to the model’s real context (e.g. `262144` for glm-5.2 on Developer/Code Refactorer/Code Reviewer, `200000` for Devstral 2 123B on Code Assistant/GitHub Assistant). Re-run the librechat-init after any change to `agents.yaml` so the DB receives the updated `model_parameters`; otherwise the runtime keeps using the 18K fallback. For very large PRs, use the quality variant (e.g. Code Reviewer with Gemini 3.1 Pro Preview, 1M context). See [AGENTS_CONTEXT_LIMIT](wip/AGENTS_CONTEXT_LIMIT.md) for the init/pruning flow.
 
 **"400 Unexpected role 'user' after role 'tool'"** after a transfer (e.g. Main Assistant → Data Analysis right after the router ran `list_upload_sessions`): The API expects an assistant turn after a tool message, but the handoff logic was appending the handoff instructions as a user message. Fixed in **dev/agents** (`MultiAgentGraph.ts`): when the last message before the handoff is a tool message, handoff instructions are now injected into that tool message’s content instead of adding a separate user message. Ensure the agents submodule/image includes this fix.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,8 @@ They are baked into the init image and written into the config volume at startup
 - **[Cursor Rules](CURSOR_RULES.md)** - Integrating services and MCP servers
 - **[Cursor MongoDB MCP](CURSOR_MONGODB_MCP.md)** - Cursor MongoDB integration
 - **[Agent Firecrawl Tools](AGENT_FIRECRAWL_TOOLS.md)** - Firecrawl MCP tool guide
+- **[MCP Server Best Practices](MCP_SERVER_BEST_PRACTICES.md)** - Conventions for building, wiring, and testing MCP servers
+
 ## WIP (Work in Progress)
 
 - **[WIP Documentation](wip/README.md)** - YTPTube production, vision architecture, agent token metadata. Vision re-enabled as **experimental/WIP** (merged into fork `main`); upstream re-attempts [agents #257](https://github.com/danny-avila/agents/pull/257), [LibreChat #13860](https://github.com/danny-avila/LibreChat/pull/13860)
@@ -67,6 +69,7 @@ They are baked into the init image and written into the config volume at startup
 ## Project
 
 - **[MCP Servers to Test](MCP_SERVERS_TODO.md)** - MCP servers to evaluate (x-twitter, Context7, Wikipedia) for Social Networks, Developer Support, and Research Assistant agents
+- **[Agent MCP Suggestions](AGENT_MCP_SUGGESTIONS.md)** - Which MCP servers suit which agents (see SERVICES.md and agents.yaml for the live setup)
 
 ## Links
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,7 +8,7 @@
 - [ ] Test LDAP login flow
 - [ ] Document LDAP configuration
 
-**Resources:** [LibreChat LDAP Documentation](dev/librechat-doc/pages/docs/configuration/authentication/ldap.mdx)
+**Resources:** [LibreChat LDAP Documentation](../dev/librechat-doc/content/docs/configuration/authentication/ldap.mdx)
 
 ### Firecrawl API Security
 - [ ] Remove public Traefik exposure for Firecrawl API (only internal Docker network access needed)


### PR DESCRIPTION
Documentation accuracy fixes (docs-only, no runtime impact).

## DEVELOPER_AGENTS.md
The model table was stale after the glm-5.2 migration and the Opus/Gemini bumps:
- Default Developer / Code Refactorer / Code Reviewer: `devstral-2-123b` -> `glm-5.2`
- Quality Developer: Claude Opus **4.6 -> 4.8**
- Quality Code Refactorer / Reviewer: **Gemini 3 Pro Preview -> Gemini 3.1 Pro Preview** (`google/gemini-3-pro-preview` -> `google/gemini-3.1-pro-preview`)
- Code Assistant + GitHub Assistant stay on `devstral-2-123b` (unchanged - they were not migrated)
- Troubleshooting context example updated to glm-5.2's 262144
- Replaced the dead **Code Research** agent (does not exist; same ghost fixed in config in #51) with the real handoff targets

## docs/README.md
Added the two index links the docs rule requires: `AGENT_MCP_SUGGESTIONS.md` and `MCP_SERVER_BEST_PRACTICES.md` (both existed but were unlinked).

## docs/TODO.md
The LDAP doc link was broken two ways: written relative to repo-root instead of docs/, and the librechat-doc repo moved `pages/` -> `content/`. Fixed to `../dev/librechat-doc/content/docs/configuration/authentication/ldap.mdx` (verified the file exists).

Larger doc restructures (LIBRECHAT_FEATURES model-groups catalog, AGENT_MCP_SUGGESTIONS 'Current Setup', CURSOR_RULES migration note) are left for a separate pass.