### PR TITLE
chore(compose): fix firecrawl Traefik label and drop stray meilisearch mount

### DIFF
--- a/docker-compose.librechat.yml
+++ b/docker-compose.librechat.yml
@@ -193,7 +193,6 @@ services:
       MEILI_MASTER_KEY: ${LIBRECHAT_MEILI_MASTER_KEY}
     volumes:
       - ./meili_data_v1.12:/meili_data
-      - mongoconfig:/mongo_configdb
     networks:
       - app-net
 

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -174,7 +174,7 @@ services:
       - "traefik.docker.network=ai-chat-interface_traefik-net"
       - "traefik.http.routers.firecrawl.rule=Host(`firecrawl.${DOMAIN:-localhost}`)"
       - "traefik.http.routers.firecrawl.entrypoints=web"
-      - "traefik.http.services.firecrawl.loadbalancer.server.url=http://firecrawl-api:3002"
+      - "traefik.http.services.firecrawl.loadbalancer.server.port=3002"
 
   playwright-service:
     extends: { file: docker-compose.websearch.yml, service: playwright-service }

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -174,7 +174,7 @@ services:
       - "traefik.docker.network=ai-chat-interface_traefik-net"
       - "traefik.http.routers.firecrawl.rule=Host(`firecrawl.${DOMAIN:-localhost}`)"
       - "traefik.http.routers.firecrawl.entrypoints=web"
-      - "traefik.http.services.firecrawl.loadbalancer.server.url=http://firecrawl-api:3002"
+      - "traefik.http.services.firecrawl.loadbalancer.server.port=3002"
 
   playwright-service:
     extends: { file: docker-compose.websearch.yml, service: playwright-service }


### PR DESCRIPTION
Two small compose correctness fixes.

**Firecrawl Traefik label (local only).** The router used `loadbalancer.server.url=http://firecrawl-api:3002` - the file/HTTP-provider form - but every other service uses `loadbalancer.server.port`, which the Docker provider expects. So `firecrawl.localhost` resolved no backend. Changed to `loadbalancer.server.port=3002` in `local.yml` and `local-dev.yml`. (Debug-only route, local stacks.)

**Stray meilisearch mount (base).** `meilisearch` mounted `mongoconfig:/mongo_configdb` - a copy-paste artifact; meilisearch only uses `/meili_data`. Removed it from the base service. No runtime effect: meilisearch never reads that path, and the `mongoconfig` volume stays in place for mongodb and the init containers. Cleans up volume/backup reasoning.

Both are safe; the meilisearch change is cosmetic (no behavior change) but touches the base file inherited by all stacks.