### PR TITLE
feat(compose): add healthchecks to rag/websearch/librechat services

### DIFF
--- a/docker-compose.librechat.yml
+++ b/docker-compose.librechat.yml
@@ -140,6 +140,12 @@ services:
       # (not on shared traefik-net where multiple containers might register mcp-linux)
       - app-net
       - traefik-net
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3080/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
 
   mongodb-init:
     image: alpine:latest
@@ -195,6 +201,12 @@ services:
       - ./meili_data_v1.12:/meili_data
     networks:
       - app-net
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:7700/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
 volumes:
   librechat-config:

--- a/docker-compose.rag.yml
+++ b/docker-compose.rag.yml
@@ -11,6 +11,12 @@ services:
       - pgdata2:/var/lib/postgresql/data
     networks:
       - app-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${LIBRECHAT_VECTORDB_USER:-vectordb} -d ${LIBRECHAT_VECTORDB_DB:-vectordb}"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   rag_api:
     container_name: rag_api
@@ -38,9 +44,16 @@ services:
       CHUNK_OVERLAP: ${RAG_CHUNK_OVERLAP:-100}
     restart: always
     depends_on:
-      - vectordb
+      vectordb:
+        condition: service_healthy
     networks:
       - app-net
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:${LIBRECHAT_RAG_PORT:-8000}/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
 volumes:
   pgdata2:

--- a/docker-compose.websearch.yml
+++ b/docker-compose.websearch.yml
@@ -268,6 +268,12 @@ services:
     depends_on:
       searxng-config-init:
         condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
   playwright-service:
     container_name: firecrawl-playwright
@@ -286,6 +292,12 @@ services:
     command: redis-server --bind 0.0.0.0
     networks:
       - firecrawl-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
   nuq-postgres:
     container_name: firecrawl-postgres


### PR DESCRIPTION
Adds healthchecks to the services that lacked them and fixes the documented `rag_api` startup race.

| Service | Probe | Tested |
|---|---|---|
| vectordb | `pg_isready` | e2e healthy under podman ✓ |
| rag_api | `GET /health` (python) | runtime + endpoint verified; **+ `depends_on vectordb: service_healthy`** |
| meilisearch | `GET /health` (wget) | /health verified via 127.0.0.1 ✓ |
| api (LibreChat) | `GET /health` (node) | runtime + endpoint verified |
| searxng | `GET /healthz` (wget) | e2e healthy under podman ✓ |
| redis | `redis-cli ping` | e2e healthy under podman ✓ |

**Key finding from testing:** all HTTP probes use `127.0.0.1`, not `localhost`. Inside these containers `localhost` resolves to IPv6 `::1` while the services bind IPv4 only, so a `localhost` probe returns connection-refused. The meilisearch `wget localhost` probe failed for exactly this reason in testing; `127.0.0.1` fixed it.

**The one behavior change:** `rag_api` now waits for `vectordb` to be healthy before starting (was `depends_on: started`, a race - rag_api could come up before Postgres accepted connections). `vectordb` reports healthy within seconds (`pg_isready`), so this only delays rag_api start slightly and removes the race.

**Validated:** YAML parses; `podman compose config` on the merged local stack exits 0 (the `service_healthy` map form + healthcheck schema are valid); the probe tools (wget/curl/redis-cli/pg_isready/node/python) are confirmed present in each image.

**Deferred deliberately:** resource limits. The heavy services run unlimited today; a blind memory cap risks OOM. Size from observed usage (docker stats / spend-monitor) in a separate pass.