### PR TITLE
feat(compose): add resource limits to rag/websearch/librechat services

### DIFF
--- a/docker-compose.librechat.yml
+++ b/docker-compose.librechat.yml
@@ -146,6 +146,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
 
   mongodb-init:
     image: alpine:latest
@@ -207,6 +215,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 20s
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
 volumes:
   librechat-config:

--- a/docker-compose.rag.yml
+++ b/docker-compose.rag.yml
@@ -17,6 +17,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 256M
 
   rag_api:
     container_name: rag_api
@@ -54,6 +62,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
 volumes:
   pgdata2:

--- a/docker-compose.websearch.yml
+++ b/docker-compose.websearch.yml
@@ -274,6 +274,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 20s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   playwright-service:
     container_name: firecrawl-playwright
@@ -298,6 +306,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
 
   nuq-postgres:
     container_name: firecrawl-postgres


### PR DESCRIPTION
Completes the create-new-service convention for these services (healthchecks landed in #59; resource limits were deferred pending sizing).

**Sized from real data**, not guessed: the host is **20 cores / 62 GiB** and observed usage is small (api ~345 MB, mongo ~255 MB, meilisearch ~14 MB; every service <1 GB and <6% CPU). So each limit sits **4-6x above real usage** - generous enough to never throttle/OOM under normal load, while still capping a runaway or memory leak.

| Service | CPU | Memory |
|---|---|---|
| api (LibreChat) | 2 | 2G |
| meilisearch | 2 | 1G |
| vectordb | 2 | 2G |
| rag_api | 1 | 1G |
| searxng | 1 | 1G |
| redis | 0.5 | 512M |

All within the documented `0.5-2 CPU / 256M-2G` convention. Reservations are modest (0.1-0.5 CPU, 64-512M).

**Honest caveat:** on a 20-core/62 GiB host with well-behaved services and lots of headroom, the practical benefit here is modest - mainly leak/runaway protection + convention compliance. The one to watch is **api memory** under heavy concurrent load (image gen + many sessions); if it ever OOMs, bump it (`restart: always` recovers).

Validated: YAML parses; `podman compose config` on the merged local stack exits 0.