### PR TITLE
feat(mcp): add Wikipedia MCP for the Research agent

### DIFF
--- a/.github/workflows/build-mcp-wikipedia.yml
+++ b/.github/workflows/build-mcp-wikipedia.yml
@@ -1,0 +1,52 @@
+name: Build and Push MCP Wikipedia Image
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - packages/mcp-wikipedia/**
+      - .github/workflows/build-mcp-wikipedia.yml
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/faktenforum/mcp-wikipedia
+          tags: |
+            type=ref,event=branch,enable={{is_not_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=dev,enable={{is_not_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./packages/mcp-wikipedia
+          file: ./packages/mcp-wikipedia/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -143,6 +143,12 @@ services:
     image: ghcr.io/faktenforum/mcp-calculator:dev
     # No Traefik labels - internal service only
 
+  mcp-wikipedia:
+    extends: { file: docker-compose.mcp-wikipedia.yml, service: mcp-wikipedia }
+    container_name: ${STACK_NAME:-prod}-mcp-wikipedia
+    image: ghcr.io/faktenforum/mcp-wikipedia:dev
+    # No Traefik labels - internal service only
+
   mcp-image-gen:
     extends: { file: docker-compose.mcp-image-gen.yml, service: mcp-image-gen }
     container_name: ${STACK_NAME:-prod}-mcp-image-gen

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -237,6 +237,14 @@ services:
       - "127.0.0.1:${MCP_CALCULATOR_PORT:-3012}:${MCP_CALCULATOR_PORT:-3012}"  # Cursor IDE – local only
     # No Traefik labels - internal service only
 
+  mcp-wikipedia:
+    extends: { file: docker-compose.mcp-wikipedia.yml, service: mcp-wikipedia }
+    container_name: ${STACK_NAME:-local}-mcp-wikipedia
+    env_file: .env.local
+    ports:
+      - "127.0.0.1:${MCP_WIKIPEDIA_PORT:-3017}:${MCP_WIKIPEDIA_PORT:-3017}"  # Cursor IDE – local only
+    # No Traefik labels - internal service only
+
   mcp-image-gen:
     extends: { file: docker-compose.mcp-image-gen.yml, service: mcp-image-gen }
     container_name: ${STACK_NAME:-local}-mcp-image-gen

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -235,6 +235,18 @@ services:
       - "127.0.0.1:${MCP_CALCULATOR_PORT:-3012}:${MCP_CALCULATOR_PORT:-3012}"  # Cursor IDE – local only
     # No Traefik labels - internal service only
 
+  mcp-wikipedia:
+    extends: { file: docker-compose.mcp-wikipedia.yml, service: mcp-wikipedia }
+    container_name: ${STACK_NAME:-local}-mcp-wikipedia
+    env_file: .env.local
+    # Override: use build for local development instead of image from registry
+    build:
+      context: ./packages/mcp-wikipedia
+      dockerfile: Dockerfile
+    ports:
+      - "127.0.0.1:${MCP_WIKIPEDIA_PORT:-3017}:${MCP_WIKIPEDIA_PORT:-3017}"  # Cursor IDE – local only
+    # No Traefik labels - internal service only
+
   mcp-image-gen:
     extends: { file: docker-compose.mcp-image-gen.yml, service: mcp-image-gen }
     container_name: ${STACK_NAME:-local}-mcp-image-gen

--- a/docker-compose.mcp-wikipedia.yml
+++ b/docker-compose.mcp-wikipedia.yml
@@ -1,0 +1,37 @@
+services:
+  mcp-wikipedia:
+    # Internal service only - not exposed via Traefik
+    # Wraps the upstream `wikipedia-mcp` pip package (streamable-http). No /health endpoint, so the
+    # healthcheck is a TCP connect. Build overridden in local/local-dev; prod/dev pull from registry.
+    # container_name is set in the extension files.
+    image: ghcr.io/faktenforum/mcp-wikipedia:latest
+    restart: always
+    environment:
+      PORT: ${MCP_WIKIPEDIA_PORT:-3017}
+      MCP_WIKIPEDIA_PORT: ${MCP_WIKIPEDIA_PORT:-3017}
+      WIKIPEDIA_ACCESS_TOKEN: ${WIKIPEDIA_ACCESS_TOKEN:-}
+    expose:
+      - "3017"
+    networks:
+      - app-net
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket,sys; s=socket.socket(); s.settimeout(3); sys.exit(0 if s.connect_ex(('127.0.0.1', 3017))==0 else 1)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    read_only: false
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+        compress: "true"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.25'
+          memory: 128M

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -132,6 +132,11 @@ services:
     container_name: ${STACK_NAME:-prod}-mcp-calculator
     # No Traefik labels - internal service only
 
+  mcp-wikipedia:
+    extends: { file: docker-compose.mcp-wikipedia.yml, service: mcp-wikipedia }
+    container_name: ${STACK_NAME:-prod}-mcp-wikipedia
+    # No Traefik labels - internal service only
+
   mcp-image-gen:
     extends: { file: docker-compose.mcp-image-gen.yml, service: mcp-image-gen }
     container_name: ${STACK_NAME:-prod}-mcp-image-gen

--- a/docs/MCP_SERVERS_TODO.md
+++ b/docs/MCP_SERVERS_TODO.md
@@ -6,7 +6,7 @@ TODO list of MCP servers to evaluate and integrate for specific agents.
 |----------------------|--------------|--------|
 | [x-twitter-mcp-server](#1-x-twitter-mcp-server) | Social Networks (Soziale Netzwerke) | [ ] |
 | [Context7](#2-context7) | Developer domain (e.g. Code Research) | [ ] |
-| [Wikipedia MCP](#3-wikipedia-mcp) | Research Assistant | [ ] |
+| [Wikipedia MCP](#3-wikipedia-mcp) | Research Assistant | [x] Done - wired to the Research agent |
 | [Code execution with MCP](#4-code-execution-with-mcp-concept) | TBD (developer / data workflows) | [ ] — still searching for suitable server |
 
 ---
@@ -42,14 +42,15 @@ TODO list of MCP servers to evaluate and integrate for specific agents.
 
 ## 3. Wikipedia MCP
 
+**Status: Done.** Implemented as the first-party `mcp-wikipedia` service (wraps the upstream `wikipedia-mcp` pip package, pinned `2.0.1`), streamable-http on port `3017` at `/mcp`, internal-only on `app-net`, and wired to the Research agent (`shared-agent-research`). See [SERVICES.md](SERVICES.md) and `packages/mcp-wikipedia/`.
+
 - **Repository:** [Rudra-ravi/wikipedia-mcp](https://github.com/Rudra-ravi/wikipedia-mcp/tree/main)
 - **Purpose:** Wikipedia search, article content, summaries, sections, links, related topics; optional multi-language and caching.
 - **Target agent:** Research Assistant
-- **Transport:** STDIO or SSE. Docker image available. Optional Wikipedia access token for rate limits.
+- **Transport:** streamable-http (`POST /mcp`). Internal Docker service.
 - **Tasks:**
-  - [ ] Test STDIO vs SSE with LibreChat
-  - [ ] Decide Docker vs external (e.g. pipx) deployment
-  - [ ] Add to stack and wire to “Research Assistant” agent
+  - [x] Decided Docker deployment via the pinned `wikipedia-mcp` pip package
+  - [x] Added to the stack and wired to the Research agent
   - [ ] Optionally configure language/country and caching
 
 ---

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -101,6 +101,7 @@ Internal Docker MCP servers are exposed on localhost when running the stack loca
 | **Linux** | Internal Docker | 3015 | `http://mcp-linux:3015/mcp` | ✅ `https://mcp-linux.{DOMAIN}/upload/*`, `/download/*`, `/status` | ✅ `localhost:3015` |
 | **YTPTube** | Internal Docker | 3010 | `http://mcp-ytptube:3010/mcp` | — | ✅ `localhost:3010` |
 | **Grounded Docs** | Internal Docker | 6280 | `http://mcp-docs:6280/mcp` | — | ✅ `localhost:6280` |
+| **Wikipedia** | Internal Docker | 3017 | `http://mcp-wikipedia:3017/mcp` | — | ✅ `localhost:3017` |
 | **GitHub** | Remote | — | `https://api.githubcopilot.com/mcp/` | N/A (external) | — |
 | **Mapbox** | Remote | — | `https://mcp.mapbox.com/mcp` | N/A (external) | — |
 
@@ -127,6 +128,8 @@ Internal Docker MCP servers are exposed on localhost when running the stack loca
 **YTPTube** — Media URL → transcript or download link. Tools: `request_transcript`, `get_status`, `request_download_link`, `get_media_info`, `get_thumbnail_url`, `list_recent_downloads`. Optional: `TRANSCRIPTION_BASE_URL` + `TRANSCRIPTION_API_KEY` for audio transcription; omit for platform-subtitles-only. Network: `app-net`. URL: `http://mcp-ytptube:3010/mcp`. [MCP YTPTube](MCP_YTPTUBE.md)
 
 **Grounded Docs** — Documentation index (websites, GitHub, npm, local files). Optional semantic search via embeddings (`MCP_DOCS_*`). Volumes: `docs-mcp-data`, `docs-mcp-config`. Network: `app-net`. URL: `http://mcp-docs:6280/mcp`. Image: `ghcr.io/faktenforum/mcp-docs:latest`. Port: `MCP_DOCS_PORT` (default 6280). [MCP Grounded Docs](MCP_DOCS.md)
+
+**Wikipedia** — Wikipedia search, article content, summaries, sections, links, related topics. Wraps the upstream `wikipedia-mcp` pip package (pinned `2.0.1`); no `/health` endpoint, so the healthcheck is a TCP connect. Used by the Research agent. Internal only. Network: `app-net`. URL: `http://mcp-wikipedia:3017/mcp`. Image: `ghcr.io/faktenforum/mcp-wikipedia:latest`. Env: `MCP_WIKIPEDIA_PORT` (3017), `WIKIPEDIA_ACCESS_TOKEN` (optional, raises API rate limits).
 
 **GitHub** — Repository management, issues, pull requests, code search; write access (create issue/PR/review) when not read-only. Remote; requires `MCP_GITHUB_PAT` (shared machine user recommended). URL: `https://api.githubcopilot.com/mcp/`. See [GitHub Machine User](GITHUB_MACHINE_USER.md).
 

--- a/env.dev.example
+++ b/env.dev.example
@@ -169,6 +169,11 @@ MCP_LINUX_DOWNLOAD_SESSION_TIMEOUT_MIN=60
 # Status page URL (for LLM to refer users to manage workspaces, sessions, terminals)
 MCP_LINUX_STATUS_PAGE_URL=https://mcp-linux.${DOMAIN}/status
 
+# MCP Wikipedia Server (Wikipedia search, articles, summaries; used by the Research agent)
+MCP_WIKIPEDIA_PORT=3017
+# Optional Wikipedia access token; raises Wikipedia API rate limits (leave empty if unused)
+WIKIPEDIA_ACCESS_TOKEN=
+
 # MCP Linux - Code index (semantic code search). Set CODE_INDEX_ENABLED=false to disable.
 # Uses OPENROUTER_KEY and OPENROUTER_BASE_URL from existing config; override here if needed.
 CODE_INDEX_ENABLED=true

--- a/env.local.example
+++ b/env.local.example
@@ -229,6 +229,11 @@ MCP_LINUX_WORKER_IDLE_TIMEOUT=1800000
 # MCP_LINUX_WORKER_REQUEST_TIMEOUT_MS=120000
 # SSH private key (base64-encoded) for GitHub machine user (optional; use same account as MCP_GITHUB_PAT). See docs/GITHUB_MACHINE_USER.md.
 MCP_LINUX_GIT_SSH_KEY=
+
+# MCP Wikipedia Server (Wikipedia search, articles, summaries; used by the Research agent)
+MCP_WIKIPEDIA_PORT=3017
+# Optional Wikipedia access token; raises Wikipedia API rate limits (leave empty if unused)
+WIKIPEDIA_ACCESS_TOKEN=
 # Default Git author for new/init repos (optional; empty = built-in). See docs/GITHUB_MACHINE_USER.md.
 MCP_LINUX_GIT_USER_NAME=
 MCP_LINUX_GIT_USER_EMAIL=

--- a/env.prod.example
+++ b/env.prod.example
@@ -162,6 +162,11 @@ MCP_LINUX_DOWNLOAD_SESSION_TIMEOUT_MIN=60
 # Status page URL (for LLM to refer users to manage workspaces, sessions, terminals)
 MCP_LINUX_STATUS_PAGE_URL=https://mcp-linux.${DOMAIN}/status
 
+# MCP Wikipedia Server (Wikipedia search, articles, summaries; used by the Research agent)
+MCP_WIKIPEDIA_PORT=3017
+# Optional Wikipedia access token; raises Wikipedia API rate limits (leave empty if unused)
+WIKIPEDIA_ACCESS_TOKEN=
+
 # MCP Linux - Code index (semantic code search). Set CODE_INDEX_ENABLED=false to disable.
 # Uses OPENROUTER_KEY and OPENROUTER_BASE_URL from existing config; override here if needed.
 CODE_INDEX_ENABLED=true

--- a/packages/librechat-init/assets/mcp-wikipedia-icon.svg
+++ b/packages/librechat-init/assets/mcp-wikipedia-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>

--- a/packages/librechat-init/config/agents.yaml
+++ b/packages/librechat-init/config/agents.yaml
@@ -12,6 +12,8 @@ agents:
     tools:
       - web_search
       - file_search
+    mcpServers:
+      - wikipedia
     category: general
     conversation_starters:
       - Research current information on climate change

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -997,6 +997,7 @@ mcpSettings:
     - '$${STACK_NAME:-prod}-mcp-docs'                # MCP Docs (Grounded Docs) service (Docker network)
     - '$${STACK_NAME:-prod}-mcp-chefkoch'            # MCP Chefkoch service (Docker network)
     - '$${STACK_NAME:-prod}-mcp-linux'                # MCP Linux service (Docker network)
+    - '$${STACK_NAME:-prod}-mcp-wikipedia'           # MCP Wikipedia service (Docker network)
     - 'api.githubcopilot.com'   # GitHub MCP Server (remote hosted)
     - 'mcp.mapbox.com'           # Mapbox MCP Server (remote hosted)
     - '$${SEARCH_MCP_DOMAIN}'  # Faktenforum Search (external; host only, e.g. search.localhost)
@@ -1006,6 +1007,17 @@ mcpSettings:
 
 # MCP Calculator Server
 mcpServers:
+  wikipedia:
+    type: streamable-http
+    url: http://$${STACK_NAME:-prod}-mcp-wikipedia:3017/mcp
+    title: Wikipedia
+    description: Look up encyclopedic facts and article summaries from Wikipedia
+    iconPath: /images/mcp-wikipedia-icon.svg
+    initTimeout: 120000
+    chatMenu: true
+    startup: true
+    serverInstructions: true
+
   calculator:
     type: streamable-http
     url: http://$${STACK_NAME:-prod}-mcp-calculator:3012/mcp

--- a/packages/mcp-wikipedia/Dockerfile
+++ b/packages/mcp-wikipedia/Dockerfile
@@ -1,0 +1,10 @@
+# Wikipedia MCP server (streamable-http). Wraps the upstream `wikipedia-mcp` pip package.
+# https://pypi.org/project/wikipedia-mcp/
+FROM python:3.12-slim
+RUN pip install --no-cache-dir wikipedia-mcp==2.0.1
+RUN useradd --create-home --uid 1000 appuser
+USER appuser
+ENV MCP_WIKIPEDIA_PORT=3017
+EXPOSE 3017
+# Optional WIKIPEDIA_ACCESS_TOKEN env raises Wikipedia API rate limits.
+CMD ["sh", "-c", "wikipedia-mcp --transport streamable-http --host 0.0.0.0 --port ${MCP_WIKIPEDIA_PORT:-3017} --path /mcp"]

--- a/packages/mcp-wikipedia/README.md
+++ b/packages/mcp-wikipedia/README.md
@@ -1,0 +1,20 @@
+# Wikipedia MCP Server
+
+Wikipedia retrieval MCP for LibreChat agents. Wraps the upstream
+[`wikipedia-mcp`](https://pypi.org/project/wikipedia-mcp/) pip package, pinned to `2.0.1`.
+
+Provides search, article content, summaries, sections, links, and related topics from Wikipedia.
+
+## Runtime
+
+- Transport: `streamable-http` on port `3017`, path `/mcp`.
+- Internal only - reachable on `app-net`, not exposed via Traefik.
+- Used by the Research agent.
+
+## Environment Variables
+
+- `MCP_WIKIPEDIA_PORT`: Server port (default: `3017`).
+- `WIKIPEDIA_ACCESS_TOKEN`: Optional. Raises Wikipedia API rate limits when set.
+
+The image installs the pinned pip package and runs the server directly; there is no `/health`
+endpoint, so the container healthcheck is a TCP connect on the port.


### PR DESCRIPTION
Gives the **Research agent** encyclopedic retrieval (it previously had only `web_search` + `file_search`).

## What
A first-party `wikipedia` MCP wrapping the upstream [`wikipedia-mcp`](https://pypi.org/project/wikipedia-mcp/) pip package (pinned **2.0.1**), served over **streamable-http on :3017/mcp**, app-net only, wired to `shared-agent-research`.

## Why a first-party build (not an external image)
No published streamable-http Docker image exists for this MCP - the upstream repo ships only a build-from-source Dockerfile and the server is a pip package. So we build a thin, **pinned** image (`python:3.12-slim` + `pip install wikipedia-mcp==2.0.1`, non-root) and publish to `ghcr.io/faktenforum/mcp-wikipedia` via GHA. This also keeps the supply chain controlled/pinned, which suits a journalism org. No `/health` endpoint, so the healthcheck is a TCP connect (same approach the former mcp-playwright used).

## Tested under podman ✅
- Image builds cleanly.
- Container reports **healthy** (TCP healthcheck).
- Logs: `Starting MCP server 'Wikipedia' ... on http://0.0.0.0:3017/mcp`, `StreamableHTTP session manager started`, `Uvicorn running on http://0.0.0.0:3017`.
- `GET /mcp` → **HTTP 406** (correct for a streamable-http endpoint hit without MCP headers; confirms the server responds).
- `podman compose config` on the merged stack exits 0.

## Files
`packages/mcp-wikipedia/{Dockerfile,README}`, `docker-compose.mcp-wikipedia.yml` + entries in local/local-dev/prod/dev, `librechat.yaml` (mcpServers + allowedDomains), the icon, `.github/workflows/build-mcp-wikipedia.yml`, env vars, and SERVICES.md + MCP_SERVERS_TODO docs.

Note: the registry image publishes on merge (GHA); local testing uses the `build:` override in `docker-compose.local.yml`.