### PR TITLE
fix(compose): mount the mongodata volume for librechat-init /mongo_data

### DIFF
--- a/docker-compose.librechat.yml
+++ b/docker-compose.librechat.yml
@@ -27,7 +27,7 @@ services:
       - ./logs:/logs
       - ./images:/images
       - ./uploads:/uploads
-      - ./data-node:/mongo_data
+      - mongodata:/mongo_data
       - ./meili_data_v1.12:/meili_data
       - mongoconfig:/mongo_configdb
     depends_on:

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -67,7 +67,7 @@ services:
       - ./logs:/logs
       - ./images:/images
       - ./uploads:/uploads
-      - ./data-node:/mongo_data
+      - mongodata:/mongo_data
       - ./meili_data_v1.12:/meili_data
       - mongoconfig:/mongo_configdb
 


### PR DESCRIPTION
`librechat-init` mounted `./data-node:/mongo_data` in the base file (`librechat.yml:30`) and the local-dev stack (`local-dev.yml:70`), but mongodb stores its data in the **`mongodata` named volume** - and `librechat-post-init` plus the local/prod/dev stacks already use `mongodata:/mongo_data`. So the init permission-fix chowned a host dir mongo doesn't use, while the real mongo volume was left untouched (latent under Docker, a real mismatch under rootless Podman).

Aligned both to `mongodata:/mongo_data`, matching the proven local/prod/dev pattern. All 10 `/mongo_data` mounts now use `mongodata`; `./data-node` is no longer referenced.

Verified: no `./data-node:/mongo_data` remains; YAML parses; `podman compose config` on the merged local-dev stack exits 0.