### PR TITLE
feat(spend-monitor): add admin-gated MCP endpoint with inline usage report

### DIFF
--- a/docker-compose.spend-monitor.yml
+++ b/docker-compose.spend-monitor.yml
@@ -26,6 +26,8 @@ services:
       # Must be in this environment block: Portainer ignores env_file, so a label-only
       # override would never reach the container in prod/dev.
       SPEND_MONITOR_ENFORCE: ${SPEND_MONITOR_ENFORCE:-off}
+      # Comma-separated emails allowed to use the spend-monitor MCP tools (empty = MCP disabled).
+      SPEND_MONITOR_ADMIN_EMAILS: ${SPEND_MONITOR_ADMIN_EMAILS:-}
     expose:
       - "3016"
     networks:

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -13,7 +13,7 @@ Application servers, databases, and infrastructure (excluding MCP servers).
 | Service | Description | Local (via Traefik) | Production (via Traefik) | Internal Only |
 |---------|-------------|---------------------|--------------------------|---------------|
 | **LibreChat** | Main AI chat interface | ✅ `http://chat.localhost` | ✅ `https://chat.{DOMAIN}` | ❌ |
-| **Spend Monitor** | Read-only org cost dashboard (reads LibreChat MongoDB) | ✅ `http://spend.localhost` | ✅ `https://spend.{DOMAIN}` (basic auth) | ❌ |
+| **Spend Monitor** | Org cost dashboard + admin-gated MCP endpoint (`/mcp`); reads LibreChat MongoDB | ✅ `http://spend.localhost` | ✅ `https://spend.{DOMAIN}` (basic auth) | ❌ |
 | **SearXNG** | Meta search engine for web search | ✅ `http://searxng.localhost` | ❌ Not exposed | ✅ Internal only |
 | **Firecrawl API** | Web scraping service | ✅ `http://firecrawl.localhost` | ❌ Not exposed | ✅ Internal only (prod/dev) |
 | **MailDev** | Development mail server | ✅ `http://maildev.localhost` | ❌ Not in production | ❌ |

--- a/docs/SPEND_MONITOR.md
+++ b/docs/SPEND_MONITOR.md
@@ -15,8 +15,9 @@ A Scaleway billing webhook and email/webhook alerts are possible later phases.
 - `GET /api/spend` — current-period spend JSON (org total, per-provider, per-model, top users)
 - `GET /` — HTML status page (auto-refreshes every 30s)
 - `POST /restore` — lift enforcement and restore balances (only when enforce is `on`/`dry-run`)
+- `POST /mcp` — MCP endpoint (admin-gated; see [MCP endpoint](#mcp-endpoint))
 
-Local: `http://localhost:3016` and `http://spend.localhost`. Prod/dev: `https://spend.${DOMAIN}` (behind Traefik basic auth).
+Local: `http://localhost:3016` and `http://spend.localhost`. Prod/dev: `https://spend.${DOMAIN}` (behind Traefik basic auth). The `/mcp` endpoint is Docker-network only (reached by LibreChat at `http://${STACK_NAME}-spend-monitor:3016/mcp`), never exposed via Traefik.
 
 ## How spend is computed
 
@@ -42,9 +43,33 @@ Spend is recorded after a completion, so the total trails real spend by at most 
 | `SPEND_MONITOR_POLL_SECONDS` | `60` | aggregation interval |
 | `SPEND_MONITOR_ENFORCE` | `off` | `off` / `dry-run` / `on` — hard stop by zeroing balances |
 | `SPEND_MONITOR_BASIC_AUTH` | — | prod/dev: Traefik basic-auth htpasswd line |
+| `SPEND_MONITOR_ADMIN_EMAILS` | — | comma-separated emails allowed to use the MCP tools; empty disables `/mcp` |
 
 The MongoDB URI is not configured separately — the service reuses LibreChat's
 `LIBRECHAT_MONGO_URI` (compose default), so it always reads the same database.
+
+## MCP endpoint
+
+The monitor also speaks MCP over `POST /mcp`, so admins can pull the spend report and
+lift a freeze from inside a LibreChat chat instead of opening the hosted page. The
+hosted page and `POST /restore` remain the ops fallback — enforcement must be operable
+when LibreChat itself is down.
+
+Tools:
+
+- `get_usage_report` — returns the current spend summary as JSON plus the dashboard as
+  an MCP-UI resource (`ui://spend-monitor/report`) rendered inline in the chat. Its
+  buttons (Refresh, and Restore when a freeze is active) post tool actions back to
+  LibreChat, arriving as new messages that ask the agent to run the matching tool.
+- `restore_balances` (requires `confirm: true`) — same effect as the dashboard's Restore
+  button / `POST /restore`.
+
+**Access control.** YAML-defined MCP servers are global in LibreChat (`chatMenu: false`
+only hides a server from the chat picker; any agent can still attach it), so the endpoint
+is gated server-side: it checks the `X-User-Email` header against
+`SPEND_MONITOR_ADMIN_EMAILS`. If that list is empty the endpoint returns `403` for every
+request (deny-by-default), since it exposes org-wide spend and a write action. The MCP
+server is wired into LibreChat as `spend` in `librechat.yaml` with the `X-User-*` headers.
 
 ## Alerting
 

--- a/env.dev.example
+++ b/env.dev.example
@@ -61,6 +61,8 @@ SPEND_MONITOR_ENFORCE=off
 # Basic auth for the Traefik-exposed dashboard (sensitive cost data). htpasswd line "user:bcrypt-hash".
 # Generate: htpasswd -nbB admin 'password'  (REQUIRED; setup-env.ts auto-escapes $ -> $$, see docs/SPEND_MONITOR.md)
 SPEND_MONITOR_BASIC_AUTH=
+# Comma-separated emails allowed to use the spend-monitor MCP tools (get_usage_report, restore_balances). Empty = MCP disabled.
+SPEND_MONITOR_ADMIN_EMAILS=
 # FIRECRAWL_REDIS_URL=redis://${STACK_NAME:-prod}-firecrawl-redis:6379
 # FIRECRAWL_PLAYWRIGHT_MICROSERVICE_URL=http://${STACK_NAME:-prod}-firecrawl-playwright:3000/scrape
 # FIRECRAWL_POSTGRES_HOST=${STACK_NAME:-prod}-firecrawl-postgres

--- a/env.local.example
+++ b/env.local.example
@@ -185,6 +185,8 @@ SPEND_MONITOR_ENFORCE=off
 # Basic auth for the dashboard, htpasswd line "user:hash" (generate: htpasswd -nbB admin <password>).
 # Enforced via Traefik in prod/dev; local is localhost-bound and does not enforce it.
 SPEND_MONITOR_BASIC_AUTH=
+# Comma-separated emails allowed to use the spend-monitor MCP tools (get_usage_report, restore_balances). Empty = MCP disabled.
+SPEND_MONITOR_ADMIN_EMAILS=
 
 # MCP OpenStreetMap Server
 MCP_OPENSTREETMAP_PORT=3004

--- a/env.prod.example
+++ b/env.prod.example
@@ -54,6 +54,8 @@ SPEND_MONITOR_ENFORCE=off
 # Basic auth for the Traefik-exposed dashboard (sensitive cost data). htpasswd line "user:bcrypt-hash".
 # Generate: htpasswd -nbB admin 'password'  (REQUIRED in prod; setup-env.ts auto-escapes $ -> $$, see docs/SPEND_MONITOR.md)
 SPEND_MONITOR_BASIC_AUTH=
+# Comma-separated emails allowed to use the spend-monitor MCP tools (get_usage_report, restore_balances). Empty = MCP disabled.
+SPEND_MONITOR_ADMIN_EMAILS=
 # FIRECRAWL_REDIS_URL=redis://${STACK_NAME:-prod}-firecrawl-redis:6379
 # FIRECRAWL_PLAYWRIGHT_MICROSERVICE_URL=http://${STACK_NAME:-prod}-firecrawl-playwright:3000/scrape
 # FIRECRAWL_POSTGRES_HOST=${STACK_NAME:-prod}-firecrawl-postgres

--- a/packages/librechat-init/assets/mcp-spend-monitor-icon.svg
+++ b/packages/librechat-init/assets/mcp-spend-monitor-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#6b7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-gauge-icon lucide-gauge"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></svg>

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -864,6 +864,7 @@ mcpSettings:
     - '$${STACK_NAME:-prod}-mcp-docs'                # MCP Docs (Grounded Docs) service (Docker network)
     - '$${STACK_NAME:-prod}-mcp-chefkoch'            # MCP Chefkoch service (Docker network)
     - '$${STACK_NAME:-prod}-mcp-linux'                # MCP Linux service (Docker network)
+    - '$${STACK_NAME:-prod}-spend-monitor'           # Spend Monitor MCP (admin-gated, Docker network)
     - '$${STACK_NAME:-prod}-mcp-wikipedia'           # MCP Wikipedia service (Docker network)
     - 'api.githubcopilot.com'   # GitHub MCP Server (remote hosted)
     - 'mcp.mapbox.com'           # Mapbox MCP Server (remote hosted)
@@ -995,6 +996,21 @@ mcpServers:
     timeout: 120000
     chatMenu: true
     startup: true
+    serverInstructions: true
+    headers:
+      X-User-ID: '{{LIBRECHAT_USER_ID}}'
+      X-User-Username: '{{LIBRECHAT_USER_USERNAME}}'
+      X-User-Email: '{{LIBRECHAT_USER_EMAIL}}'
+
+  spend:
+    type: streamable-http
+    url: http://$${STACK_NAME:-prod}-spend-monitor:3016/mcp
+    title: Spend Monitor
+    description: Org-wide LibreChat spend report and budget enforcement controls (admins only)
+    iconPath: /images/mcp-spend-monitor-icon.svg
+    initTimeout: 120000
+    chatMenu: false
+    startup: false
     serverInstructions: true
     headers:
       X-User-ID: '{{LIBRECHAT_USER_ID}}'

--- a/packages/spend-monitor/package.json
+++ b/packages/spend-monitor/package.json
@@ -10,10 +10,12 @@
     "lint": "eslint . --ext .ts"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "express": "^5.2.1",
     "mongodb": "^6.12.0",
     "pino": "^10.3.1",
-    "dotenv": "^17.3.1"
+    "dotenv": "^17.3.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/packages/spend-monitor/src/mcp.ts
+++ b/packages/spend-monitor/src/mcp.ts
@@ -1,0 +1,159 @@
+/**
+ * Spend-monitor MCP server.
+ *
+ * Exposes the org spend dashboard as an MCP-UI resource and a balance-restore
+ * action for admins. Access is gated in server.ts by the X-User-Email allowlist.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Db } from 'mongodb';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import * as z from 'zod';
+import type { Config } from './config.ts';
+import type { Snapshot } from './aggregate.ts';
+import type { EnforceState } from './enforce.ts';
+import { restoreBalances } from './enforce.ts';
+import { renderMcpUi } from './page.ts';
+import { logger } from './utils/logger.ts';
+
+const SERVER_NAME = 'spend-monitor-mcp';
+const SERVER_VERSION = '1.0.0';
+
+/** Live accessors into the running server's state. */
+export interface McpDeps {
+  getSnapshot: () => Snapshot | null;
+  getEnforceState: () => EnforceState;
+  refresh: () => Promise<void>;
+  cfg: Config;
+  db: Db;
+}
+
+function uiResource(uri: string, html: string) {
+  return { type: 'resource' as const, resource: { uri, mimeType: 'text/html' as const, text: html } };
+}
+
+function textResult(obj: unknown, isError = false) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(obj, null, 2) }], isError };
+}
+
+function createMcpServer(deps: McpDeps): McpServer {
+  const server = new McpServer(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    {
+      capabilities: { tools: {} },
+      instructions:
+        'Org-wide LibreChat spend monitor (admins only). get_usage_report returns the current ' +
+        'spend dashboard as an interactive UI resource - place its marker (\\ui{id}) in your reply. ' +
+        'restore_balances lifts an active spending freeze and restores user balances.',
+    },
+  );
+
+  server.registerTool(
+    'get_usage_report',
+    {
+      description:
+        'Get the current org-wide LibreChat spend report (total vs budget, per provider, per model, top users) ' +
+        'and enforcement state. Includes a dashboard UI resource - place its marker (\\ui{id}) in your reply.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        let snap = deps.getSnapshot();
+        if (!snap) {
+          await deps.refresh();
+          snap = deps.getSnapshot();
+        }
+        if (!snap) {
+          return textResult({ error: 'No spend data available yet. Try again shortly.' }, true);
+        }
+        const enforcement = deps.getEnforceState();
+        const summary = {
+          period: snap.period,
+          period_start: snap.periodStart,
+          budget_usd: snap.budgetUsd,
+          spent_usd: snap.spentUsd,
+          used_ratio: snap.usedRatio,
+          level: snap.level,
+          eur: snap.eur,
+          enforce: deps.cfg.enforce,
+          enforcement: { active: enforcement.active, since: enforcement.since, reason: enforcement.reason },
+          by_provider: snap.byProvider,
+          top_users: snap.topUsers.slice(0, 5),
+          updated_at: snap.updatedAt,
+        };
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify(summary, null, 2) },
+            uiResource('ui://spend-monitor/report', renderMcpUi(snap, deps.cfg.enforce, enforcement)),
+          ],
+        };
+      } catch (error) {
+        logger.error({ error: error instanceof Error ? error.message : String(error) }, 'get_usage_report failed');
+        return textResult({ error: error instanceof Error ? error.message : String(error) }, true);
+      }
+    },
+  );
+
+  server.registerTool(
+    'restore_balances',
+    {
+      description:
+        'Lift an active spending freeze and restore all user balances from the pre-freeze snapshot. ' +
+        'Suppresses re-enforcement for the current period. Requires confirm: true.',
+      inputSchema: {
+        confirm: z.boolean().describe('Must be true to lift the freeze and restore balances'),
+      },
+    },
+    async (args) => {
+      try {
+        if (!args.confirm) {
+          return textResult({ error: 'Must pass confirm: true to restore balances.' }, true);
+        }
+        if (deps.cfg.enforce === 'off') {
+          return textResult({ error: 'Enforcement is disabled (SPEND_MONITOR_ENFORCE=off); nothing to restore.' }, true);
+        }
+        const snap = deps.getSnapshot();
+        const dryRun = deps.cfg.enforce !== 'on';
+        const result = await restoreBalances(deps.db, dryRun, snap?.periodStart ?? null);
+        await deps.refresh();
+        return textResult({
+          restored: result.restored,
+          dry_run: dryRun,
+          suppressed_for_period: snap?.periodStart ?? null,
+        });
+      } catch (error) {
+        logger.error({ error: error instanceof Error ? error.message : String(error) }, 'restore_balances failed');
+        return textResult({ error: error instanceof Error ? error.message : String(error) }, true);
+      }
+    },
+  );
+
+  return server;
+}
+
+/** Creates a new MCP session (server + transport) registered in the transport map. */
+export function createSession(
+  deps: McpDeps,
+  transports: Map<string, StreamableHTTPServerTransport>,
+): { server: McpServer; transport: StreamableHTTPServerTransport } {
+  const server = createMcpServer(deps);
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+    enableJsonResponse: true,
+    onsessioninitialized: (sessionId: string) => {
+      logger.info({ sessionId, totalSessions: transports.size + 1 }, 'MCP session initialized');
+      transports.set(sessionId, transport);
+    },
+  });
+
+  server.server.onclose = async () => {
+    const sid = transport.sessionId;
+    if (sid && transports.has(sid)) {
+      logger.info({ sessionId: sid, totalSessions: transports.size - 1 }, 'MCP session closed');
+      transports.delete(sid);
+    }
+  };
+
+  return { server, transport };
+}

--- a/packages/spend-monitor/src/page.ts
+++ b/packages/spend-monitor/src/page.ts
@@ -25,12 +25,54 @@ function rows(cells: string[][]): string {
   return cells.map((r) => `<tr>${r.map((c) => `<td>${c}</td>`).join('')}</tr>`).join('');
 }
 
-function enforceStrip(mode: EnforceMode, e: EnforceState): string {
+const STYLES = `
+  :root { color-scheme: light dark; }
+  body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; padding: 1.5rem; background: #0b0f14; color: #e5e7eb; }
+  .wrap { max-width: 880px; margin: 0 auto; }
+  .top { display: flex; align-items: center; justify-content: space-between; gap: .5rem; }
+  h1 { font-size: 1.1rem; font-weight: 600; color: #9ca3af; margin: 0 0 1rem; }
+  .banner { border-radius: 10px; padding: 1.25rem 1.5rem; }
+  .level { font-size: 0.8rem; letter-spacing: 0.08em; opacity: 0.9; }
+  .headline { font-size: 2rem; font-weight: 700; margin: 0.25rem 0; }
+  .sub { font-size: 0.9rem; opacity: 0.9; }
+  .bar { height: 8px; background: rgba(255,255,255,0.2); border-radius: 999px; margin-top: 0.9rem; overflow: hidden; }
+  .bar > span { display: block; height: 100%; background: rgba(255,255,255,0.85); }
+  .enforce { border-radius: 10px; padding: 0.8rem 1.1rem; margin-top: 1rem; font-size: 0.9rem; }
+  .enforce.active { background: #7f1d1d; color: #fee2e2; }
+  .enforce.armed { background: #1f2937; color: #9ca3af; }
+  .btn { background: #fee2e2; color: #7f1d1d; border: 0; border-radius: 6px; padding: 0.35rem 0.7rem; font-weight: 600; cursor: pointer; }
+  .btn.ghost { background: #1f2937; color: #d1d5db; }
+  .enforce .btn { margin-left: 0.6rem; }
+  table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.9rem; }
+  th, td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid #1f2937; }
+  td:last-child, th:last-child { text-align: right; font-variant-numeric: tabular-nums; }
+  section { margin-top: 1.75rem; }
+  section h2 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af; margin: 0 0 0.3rem; }
+  footer { margin-top: 2rem; font-size: 0.78rem; color: #6b7280; }
+  code { color: #93c5fd; }
+`;
+
+/** Posts iframe size and forwards tool actions. Used only by the MCP variant. */
+const MCP_JS = `
+(function(){
+  function post(){var b=document.body?document.body.scrollHeight:0;window.parent.postMessage({type:'ui-size-change',payload:{width:document.documentElement.scrollWidth,height:Math.max(document.documentElement.scrollHeight,b)}},'*');}
+  if(window.ResizeObserver){var ro=new ResizeObserver(post);ro.observe(document.documentElement);if(document.body)ro.observe(document.body);}
+  window.addEventListener('load',post);window.addEventListener('resize',post);setTimeout(post,60);post();
+})();
+function uiTool(name,params,confirmMsg){if(confirmMsg&&!window.confirm(confirmMsg))return;window.parent.postMessage({type:'tool',payload:{toolName:name,params:params||{}}},'*');}`;
+
+type Variant = 'hosted' | 'mcp';
+
+function enforceStrip(mode: EnforceMode, e: EnforceState, variant: Variant): string {
   if (e.active) {
     const dry = mode === 'dry-run' ? ' (DRY-RUN)' : '';
+    const restore =
+      variant === 'mcp'
+        ? `<button class="btn" onclick="uiTool('restore_balances',{confirm:true},'Restore all balances and lift the spending freeze?')">Restore balances</button>`
+        : `<button class="btn" onclick="if(confirm('Restore all balances and lift the spending freeze?')){this.disabled=true;fetch('/restore',{method:'POST'}).then(()=>location.reload())}">Restore balances</button>`;
     return `<div class="enforce active">
       <strong>&#9940; Enforcement active${dry}</strong> &mdash; all user balances zeroed since <code>${esc(e.since ?? '')}</code>. ${esc(e.reason ?? '')}
-      <button onclick="if(confirm('Restore all balances and lift the spending freeze?')){this.disabled=true;fetch('/restore',{method:'POST'}).then(()=>location.reload())}">Restore balances</button>
+      ${restore}
     </div>`;
   }
   if (e.overridePeriodStart != null) {
@@ -42,10 +84,12 @@ function enforceStrip(mode: EnforceMode, e: EnforceState): string {
   return '';
 }
 
-export function renderPage(
+/** Renders the shared dashboard body (banner, enforcement, tables, footer). */
+function dashboardBody(
   s: Snapshot,
   mode: EnforceMode,
   enforcement: EnforceState,
+  variant: Variant,
   pollSeconds: number,
 ): string {
   const c = COLORS[s.level];
@@ -59,48 +103,23 @@ export function renderPage(
   const modelRows = rows(s.byModel.slice(0, 20).map((m) => [esc(m.model), m.provider, usd(m.usd)]));
   const userRows = rows(s.topUsers.map((u) => [esc(u.user), usd(u.usd)]));
 
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta http-equiv="refresh" content="${pollSeconds}" />
-<title>LibreChat spend monitor</title>
-<style>
-  :root { color-scheme: light dark; }
-  body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; padding: 1.5rem; background: #0b0f14; color: #e5e7eb; }
-  .wrap { max-width: 880px; margin: 0 auto; }
-  h1 { font-size: 1.1rem; font-weight: 600; color: #9ca3af; margin: 0 0 1rem; }
-  .banner { background: ${c.bg}; color: ${c.fg}; border-radius: 10px; padding: 1.25rem 1.5rem; }
-  .level { font-size: 0.8rem; letter-spacing: 0.08em; opacity: 0.9; }
-  .headline { font-size: 2rem; font-weight: 700; margin: 0.25rem 0; }
-  .sub { font-size: 0.9rem; opacity: 0.9; }
-  .bar { height: 8px; background: rgba(255,255,255,0.2); border-radius: 999px; margin-top: 0.9rem; overflow: hidden; }
-  .bar > span { display: block; height: 100%; width: ${barWidth}%; background: rgba(255,255,255,0.85); }
-  .enforce { border-radius: 10px; padding: 0.8rem 1.1rem; margin-top: 1rem; font-size: 0.9rem; }
-  .enforce.active { background: #7f1d1d; color: #fee2e2; }
-  .enforce.armed { background: #1f2937; color: #9ca3af; }
-  .enforce button { margin-left: 0.6rem; background: #fee2e2; color: #7f1d1d; border: 0; border-radius: 6px; padding: 0.35rem 0.7rem; font-weight: 600; cursor: pointer; }
-  table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.9rem; }
-  th, td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid #1f2937; }
-  td:last-child, th:last-child { text-align: right; font-variant-numeric: tabular-nums; }
-  section { margin-top: 1.75rem; }
-  section h2 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af; margin: 0 0 0.3rem; }
-  footer { margin-top: 2rem; font-size: 0.78rem; color: #6b7280; }
-  code { color: #93c5fd; }
-</style>
-</head>
-<body>
-<div class="wrap">
-  <h1>LibreChat &mdash; org spend monitor</h1>
-  <div class="banner">
+  const heading =
+    variant === 'mcp'
+      ? `<div class="top"><h1>LibreChat &mdash; org spend monitor</h1><button class="btn ghost" onclick="uiTool('get_usage_report',{})">Refresh</button></div>`
+      : `<h1>LibreChat &mdash; org spend monitor</h1>`;
+
+  const refreshNote =
+    variant === 'mcp' ? 'use the Refresh button' : `auto-refresh ${pollSeconds}s`;
+
+  return `${heading}
+  <div class="banner" style="background:${c.bg};color:${c.fg}">
     <div class="level">${c.label} &middot; ${pct}% of budget</div>
     <div class="headline">${usd(s.spentUsd)} <span style="opacity:.6;font-size:1.2rem">/ ${usd(s.budgetUsd)}</span></div>
     <div class="sub">${eur(s.eur.spent)} / ${eur(s.eur.budget)} &middot; period: ${s.period}</div>
-    <div class="bar"><span></span></div>
+    <div class="bar"><span style="width:${barWidth}%"></span></div>
   </div>
 
-  ${enforceStrip(mode, enforcement)}
+  ${enforceStrip(mode, enforcement, variant)}
 
   <section>
     <h2>By provider</h2>
@@ -118,10 +137,46 @@ export function renderPage(
   </section>
 
   <footer>
-    period start <code>${esc(s.periodStart)}</code> &middot; updated <code>${esc(s.updatedAt)}</code> &middot; auto-refresh ${pollSeconds}s &middot;
+    period start <code>${esc(s.periodStart)}</code> &middot; updated <code>${esc(s.updatedAt)}</code> &middot; ${refreshNote} &middot;
     enforce: <code>${mode}</code> &middot; 1,000,000 credits = $1 &middot; EUR display rate ${s.eur.rate}
-  </footer>
-</div>
+  </footer>`;
+}
+
+/** Full hosted status page (auto-refreshing, with a fetch-based Restore button). */
+export function renderPage(
+  s: Snapshot,
+  mode: EnforceMode,
+  enforcement: EnforceState,
+  pollSeconds: number,
+): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="refresh" content="${pollSeconds}" />
+<title>LibreChat spend monitor</title>
+<style>${STYLES}</style>
+</head>
+<body>
+<div class="wrap">${dashboardBody(s, mode, enforcement, 'hosted', pollSeconds)}</div>
+</body>
+</html>`;
+}
+
+/** Embedded MCP-UI variant: no meta-refresh; buttons post tool actions. */
+export function renderMcpUi(s: Snapshot, mode: EnforceMode, enforcement: EnforceState): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>LibreChat spend monitor</title>
+<style>${STYLES}</style>
+</head>
+<body>
+<div class="wrap">${dashboardBody(s, mode, enforcement, 'mcp', 0)}</div>
+<script>${MCP_JS}</script>
 </body>
 </html>`;
 }

--- a/packages/spend-monitor/src/server.ts
+++ b/packages/spend-monitor/src/server.ts
@@ -17,7 +17,8 @@
 import 'dotenv/config';
 import { fileURLToPath } from 'node:url';
 import express from 'express';
-import type { Request, Response } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { loadConfig } from './config.ts';
 import { connectMongo, closeMongo } from './mongo.ts';
 import { aggregate } from './aggregate.ts';
@@ -26,6 +27,8 @@ import { logNotifier } from './notify.ts';
 import { getEnforceState, enforceCap, restoreBalances, clearStaleOverride } from './enforce.ts';
 import type { EnforceState } from './enforce.ts';
 import { renderPage } from './page.ts';
+import { setupMcpEndpoints, extractUserContext } from './utils/http-server.ts';
+import { createSession } from './mcp.ts';
 import { logger } from './utils/logger.ts';
 
 const SERVER_NAME = 'spend-monitor';
@@ -80,10 +83,6 @@ async function main(): Promise<void> {
   const app = express();
   app.disable('x-powered-by');
 
-  app.get('/health', (_req: Request, res: Response) => {
-    res.json({ status: 'ok', server: SERVER_NAME, version: SERVER_VERSION });
-  });
-
   app.get('/api/spend', async (_req: Request, res: Response) => {
     if (!latest) await refresh();
     if (!latest) {
@@ -114,6 +113,44 @@ async function main(): Promise<void> {
     res.json({ restored: result.restored, dryRun: cfg.enforce !== 'on', suppressedForPeriod: latest?.periodStart ?? null });
   });
 
+  // ── MCP endpoint (admin-gated) ─────────────────────────────────────────────
+  // YAML-defined MCP servers are global in LibreChat, so gate on the X-User-Email
+  // header against an allowlist. Empty/unset allowlist disables the endpoint.
+  const transports = new Map<string, StreamableHTTPServerTransport>();
+  const adminEmails = new Set(
+    (process.env.SPEND_MONITOR_ADMIN_EMAILS ?? '')
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  app.use('/mcp', express.json({ limit: '1mb' }));
+  app.use('/mcp', (req: Request, res: Response, next: NextFunction) => {
+    if (adminEmails.size === 0) {
+      res.status(403).json({ error: 'spend-monitor MCP disabled: SPEND_MONITOR_ADMIN_EMAILS is not set' });
+      return;
+    }
+    const ctx = extractUserContext(req.headers);
+    if (!ctx || !adminEmails.has(ctx.email.toLowerCase())) {
+      res.status(403).json({ error: 'Not authorized for spend-monitor tools' });
+      return;
+    }
+    next();
+  });
+
+  setupMcpEndpoints(app, {
+    serverName: SERVER_NAME,
+    version: SERVER_VERSION,
+    port: cfg.port,
+    transports,
+    createServer: () =>
+      createSession(
+        { getSnapshot: () => latest, getEnforceState: () => enforceState, refresh, cfg, db },
+        transports,
+      ),
+    logger,
+  });
+
   const server = app.listen(cfg.port, '0.0.0.0', () => {
     logger.info(
       {
@@ -134,6 +171,14 @@ async function main(): Promise<void> {
   const shutdown = async () => {
     logger.info('Shutting down...');
     clearInterval(timer);
+    for (const transport of transports.values()) {
+      try {
+        await transport.close();
+      } catch (error) {
+        logger.error({ error: error instanceof Error ? error.message : String(error) }, 'Error closing MCP transport');
+      }
+    }
+    transports.clear();
     await new Promise<void>((resolve) => server.close(() => resolve()));
     await closeMongo();
     process.exit(0);

--- a/packages/spend-monitor/src/utils/http-server.ts
+++ b/packages/spend-monitor/src/utils/http-server.ts
@@ -1,0 +1,156 @@
+/**
+ * HTTP server utilities for the spend-monitor MCP endpoint.
+ *
+ * Mirrors the mcp-calculator helper and adds user-context extraction from the
+ * LibreChat X-User-* headers (used for admin gating).
+ */
+
+import express, { type Request, type Response } from 'express';
+import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+/** User context extracted from LibreChat request headers. */
+export interface UserContext {
+  userId: string;
+  email: string;
+  username: string;
+}
+
+/**
+ * Extracts user context from LibreChat request headers.
+ * LibreChat sends X-User-ID / X-User-Email / X-User-Username when the mcpServers
+ * entry is configured with {{LIBRECHAT_USER_*}} placeholders.
+ */
+export function extractUserContext(headers: Request['headers']): UserContext | null {
+  const userId = headers['x-user-id'];
+  const email = headers['x-user-email'];
+  const username = headers['x-user-username'];
+  if (!email || typeof email !== 'string') return null;
+  return {
+    userId: typeof userId === 'string' ? userId : '',
+    email,
+    username: typeof username === 'string' ? username : '',
+  };
+}
+
+export function getSessionId(headers: Request['headers']): string | undefined {
+  const header = headers['mcp-session-id'] || headers['Mcp-Session-Id'];
+  return typeof header === 'string' ? header : undefined;
+}
+
+export function sendErrorResponse(
+  res: Response,
+  status: number,
+  code: number,
+  message: string,
+  id: unknown = null,
+): void {
+  if (res.headersSent) return;
+  res.status(status).json({ jsonrpc: '2.0', error: { code, message }, id });
+}
+
+type Logger = { info: (obj: unknown, msg?: string) => void; error: (obj: unknown, msg?: string) => void };
+
+export interface HttpServerConfig {
+  serverName: string;
+  version: string;
+  port: number;
+  transports: Map<string, StreamableHTTPServerTransport>;
+  createServer: () => {
+    server: { connect: (transport: StreamableHTTPServerTransport) => Promise<void> };
+    transport: StreamableHTTPServerTransport;
+  };
+  logger?: Logger;
+}
+
+/** Registers GET /health and GET/POST/DELETE /mcp on the app. */
+export function setupMcpEndpoints(app: express.Application, config: HttpServerConfig): void {
+  const { serverName, version, transports, createServer, logger } = config;
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', server: serverName, version, activeSessions: transports.size });
+  });
+
+  app.get('/mcp', async (req: Request, res: Response) => {
+    const sessionId = getSessionId(req.headers);
+    if (!sessionId) {
+      sendErrorResponse(res, 400, -32000, 'Bad Request: No session ID provided');
+      return;
+    }
+    const transport = transports.get(sessionId);
+    if (!transport) {
+      sendErrorResponse(res, 404, -32000, 'Session not found');
+      return;
+    }
+    try {
+      await transport.handleRequest(req, res, null);
+    } catch (error) {
+      logger?.error(
+        { error: error instanceof Error ? error.message : String(error), sessionId },
+        'Error handling SSE stream request',
+      );
+      sendErrorResponse(res, 500, -32603, 'Internal server error');
+    }
+  });
+
+  app.delete('/mcp', async (req: Request, res: Response) => {
+    const sessionId = getSessionId(req.headers);
+    if (!sessionId) {
+      sendErrorResponse(res, 400, -32000, 'Bad Request: No session ID provided');
+      return;
+    }
+    const transport = transports.get(sessionId);
+    if (!transport) {
+      sendErrorResponse(res, 404, -32000, 'Session not found');
+      return;
+    }
+    try {
+      await transport.handleRequest(req, res, req.body);
+      transports.delete(sessionId);
+      logger?.info({ sessionId, totalSessions: transports.size }, 'Session deleted');
+    } catch (error) {
+      logger?.error(
+        { error: error instanceof Error ? error.message : String(error), sessionId },
+        'Error handling session termination',
+      );
+      sendErrorResponse(res, 500, -32603, 'Error handling session termination');
+    }
+  });
+
+  app.post('/mcp', async (req: Request, res: Response) => {
+    try {
+      const sessionId = getSessionId(req.headers);
+      const requestId =
+        typeof req.body === 'object' && req.body !== null && 'id' in req.body ? req.body.id : null;
+
+      if (sessionId) {
+        const transport = transports.get(sessionId);
+        if (transport) {
+          await transport.handleRequest(req, res, req.body);
+          return;
+        }
+        sendErrorResponse(res, 404, -32000, 'Session not found', requestId);
+        return;
+      }
+
+      const isInitialize =
+        typeof req.body === 'object' &&
+        req.body !== null &&
+        'method' in req.body &&
+        req.body.method === 'initialize';
+      if (!isInitialize) {
+        sendErrorResponse(res, 400, -32000, 'Bad Request: No session ID provided', requestId);
+        return;
+      }
+
+      const { server, transport } = createServer();
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger?.error({ error: errorMessage }, 'Error handling MCP request');
+      const requestId =
+        typeof req.body === 'object' && req.body !== null && 'id' in req.body ? req.body.id : null;
+      sendErrorResponse(res, 500, -32603, 'Internal server error', requestId);
+    }
+  });
+}


### PR DESCRIPTION
## What

Adds an MCP endpoint to spend-monitor so admins can view the org spend report and lift a balance freeze from inside a LibreChat chat.

- `POST /mcp` (streamable-http) with two tools:
  - `get_usage_report` — spend summary as JSON + the dashboard as an MCP-UI resource (`ui://spend-monitor/report`) rendered inline; its Refresh/Restore buttons post tool actions back to the agent.
  - `restore_balances` (requires `confirm: true`) — same effect as the dashboard's Restore button / `POST /restore`.
- `page.ts` refactored into a shared dashboard body with `renderPage` (hosted, meta-refresh + fetch Restore) and `renderMcpUi` (no refresh; tool-action buttons) variants.
- Wired into `librechat.yaml` as `spend` (`chatMenu: false`, `startup: false`) with `X-User-*` headers + icon; added to `mcpSettings.allowedDomains`.

## Access control

YAML-defined MCP servers are global in LibreChat (`chatMenu: false` only hides the picker; any agent can attach the server), so the endpoint is gated server-side on `X-User-Email` against `SPEND_MONITOR_ADMIN_EMAILS`. **Empty allowlist ⇒ 403 for every request** (deny-by-default), since it exposes org-wide spend and a write action.

## Why

The hosted dashboard stays as the ops fallback - enforcement/restore must be operable when LibreChat itself is down - but for day-to-day checks an inline report in chat is faster and doesn't need the basic-auth page.

## Verification

`tsc --noEmit` clean; compose + `librechat.yaml` validate. Real HTTP smoke test through the MCP layer confirmed: unauthenticated → 403; admin `initialize` → session; `tools/list` → both tools; `get_usage_report` → returns the `ui://` dashboard resource. Rendering in a real chat needs the running stack (see plan verification).

## Note

Depends on nothing in #68; both target `main` and touch disjoint hunks of the shared env/SERVICES.md files, so they merge independently.