### PR TITLE
fix(librechat): set DOMAIN_SERVER, stop mapbox blocking unrelated turns

### DIFF
--- a/docker-compose.librechat.yml
+++ b/docker-compose.librechat.yml
@@ -115,6 +115,11 @@ services:
       FIRECRAWL_API_URL: ${FIRECRAWL_API_URL:-http://${STACK_NAME:-prod}-firecrawl-api:3002}
       FIRECRAWL_VERSION: ${FIRECRAWL_VERSION:-v2}
       DOMAIN_CLIENT: ${DOMAIN_CLIENT:-http://chat.localhost}
+      # Public base URL of this same container (frontend + backend share one host here via
+      # Traefik). Used for OAuth redirect_uris (social logins, actions, admin SSO, MCP OAuth
+      # e.g. Mapbox) - unset, LibreChat falls back to http://localhost:3080, which breaks
+      # those flows outside of a developer's own machine.
+      DOMAIN_SERVER: ${DOMAIN_SERVER:-${DOMAIN_CLIENT:-http://chat.localhost}}
       SEARXNG_BASE_URL: ${LIBRECHAT_SEARXNG_URL:-http://${STACK_NAME:-prod}-searxng:8080}
       SEARCH: ${LIBRECHAT_SEARCH_ENABLED:-true}
       MEILI_MASTER_KEY: ${LIBRECHAT_MEILI_MASTER_KEY}

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -1037,7 +1037,12 @@ mcpServers:
     initTimeout: 120000
     timeout: 150000
     chatMenu: true
-    startup: true
+    # mcp.mapbox.com requires its own per-user OAuth regardless of the bearer header above.
+    # Operator-configured MCP servers are global (connected regardless of which agent/tools
+    # a turn actually uses), so startup:true made ANY agent turn - even ones with no use for
+    # Mapbox - block on this OAuth requirement. startup:false makes the connection lazy: it
+    # only triggers (and only blocks) when a turn actually calls a Mapbox tool.
+    startup: false
     serverInstructions: true
 
   search:


### PR DESCRIPTION
## Summary

Found while investigating a production report: asking the Assistant agent to review a GitHub PR instead returned a Mapbox "Authentifizierung erforderlich" card, and clicking through it tried to redirect to `localhost:3080` - which obviously doesn't work in production.

Two separate, compounding bugs:

- **`DOMAIN_SERVER` was never set anywhere** (only `DOMAIN_CLIENT` is). LibreChat's OAuth redirect_uri computation (`packages/api/src/mcp/oauth/handler.ts`, used for social logins, actions, admin SSO, and MCP OAuth) falls back to `http://localhost:3080` when it's unset - so *any* OAuth flow through this backend, in *any* environment including prod, would redirect to a URL that only exists on a developer's own machine. Now set to mirror `DOMAIN_CLIENT` (they're the same host here since Traefik routes frontend and backend through one container).
- **Mapbox's `startup: true` blocked unrelated agent turns.** Operator-configured MCP servers in `librechat.yaml` connect globally regardless of which agent/tools a given turn actually uses (`chatMenu`/agent tool lists don't scope this). `mcp.mapbox.com` requires its own per-user OAuth regardless of the static bearer token we send, so with eager `startup: true`, *any* agent turn - including ones that never touch Mapbox, like a GitHub PR review - blocked on Mapbox's OAuth requirement. Set to `startup: false` so the connection is lazy: it only triggers (and only blocks) when a turn actually calls a Mapbox tool.

## Test plan

- [x] `docker compose config` resolves `DOMAIN_SERVER` to the same value as `DOMAIN_CLIENT` against both `env.local.example` and `env.prod.example`
- [x] Live-tested on a local podman stack: before the fix, asking the Assistant to summarize a Wikipedia article got blocked by the same Mapbox "Authentifizierung erforderlich" card seen in prod; after the fix, the same request goes straight to the Wikipedia tool call with no Mapbox interference
- [x] `DOMAIN_SERVER` verified present with the expected value inside the recreated `api` container