### PR TITLE
fix(librechat): wire up the Faktenforum Search MCP for the Faktencheck agent

### DIFF
--- a/docker-compose.librechat.yml
+++ b/docker-compose.librechat.yml
@@ -51,6 +51,7 @@ services:
       LIBRECHAT_API_URL: ${LIBRECHAT_API_URL:-http://api:3080}
       LIBRECHAT_JWT_SECRET: ${LIBRECHAT_JWT_SECRET}
       JWT_SECRET: ${LIBRECHAT_JWT_SECRET}
+      SEARCH_MCP_URL: ${SEARCH_MCP_URL:-}
     volumes:
       - librechat-config:/app/config
       - mongodata:/mongo_data
@@ -128,6 +129,7 @@ services:
       OCR_BASEURL: ${LIBRECHAT_OCR_BASEURL:-https://api.mistral.ai/v1}
       MCP_GITHUB_PAT: ${MCP_GITHUB_PAT:-}
       MCP_MAPBOX_ACCESS_TOKEN: ${MCP_MAPBOX_ACCESS_TOKEN:-}
+      SEARCH_MCP_API_KEY: ${SEARCH_MCP_API_KEY:-}
     volumes:
       - ./images:/app/client/public/images
       - ./uploads:/app/uploads

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -1069,6 +1069,12 @@ mcpServers:
     iconPath: /images/mcp-search-icon.svg
     headers:
       Authorization: "Bearer ${SEARCH_MCP_API_KEY}"
+    # Static admin-managed Bearer key, not OAuth. Without this, LibreChat's startup
+    # OAuth probe hits the URL with no Authorization header, gets a 401 + WWW-Authenticate
+    # challenge from the search API, and misclassifies the server as requiring OAuth -
+    # which skips the real (authenticated) inspection, so capabilities/tools never load
+    # and the Faktencheck agent has no working tools.
+    requiresOAuth: false
     initTimeout: 120000
     chatMenu: true
     startup: true


### PR DESCRIPTION
## Summary

The Faktencheck agent's Search MCP integration (added in #28/#29) has never actually worked in any environment - three separate gaps left it broken:

- `packages/librechat-init/config/librechat.yaml`: the `search` server uses a static admin-managed Bearer key (`headers.Authorization`), but LibreChat's startup OAuth-detector probes the URL with no auth header first. It gets a `401` + `WWW-Authenticate: Bearer` challenge and misclassifies the server as OAuth-only, which skips the real (authenticated) inspection entirely - so capabilities/tools never load at startup. Fixed with `requiresOAuth: false`.
- `docker-compose.librechat.yml` (`api` service): `SEARCH_MCP_API_KEY` was never forwarded into the container's own environment, unlike `MCP_GITHUB_PAT`/`MCP_MAPBOX_ACCESS_TOKEN`. Without it, the `${SEARCH_MCP_API_KEY}` placeholder in the header can't resolve at runtime, so even a real connection attempt gets `401`.
- `docker-compose.librechat.yml` (`librechat-post-init` service): `SEARCH_MCP_URL` was never forwarded there either, so `gateOptionalSearchAgents()` always saw it as unset and permanently omitted the Faktencheck agent from being created at all, in every environment.

## Test plan

- [x] Verified locally against `dev-api.faktenforum.org/search/mcp`: search MCP connects at startup and discovers all 3 tools (`search_factchecks`, `get_factcheck`, `list_categories`)
- [x] Faktencheck agent gets created (previously never existed in the DB)
- [x] Live chat test: agent calls `search_factchecks_mcp_search({"query":"Impfungen","language":"de"})` and returns real, cited fact-check results
- [ ] Deploy: dev/prod `chat` stacks need `SEARCH_MCP_URL`, `SEARCH_MCP_API_KEY` (must match the search stack's `SEARCH_BOOTSTRAP_MCP_KEY`), `SEARCH_MCP_DOMAIN` set in Portainer (env_file is ignored there)

https://claude.ai/code/session_0132zBzKju1SMUVkqVvDg5iK