### PR TITLE
chore: remove dead SEARCH_API_KEY config

### DIFF
--- a/env.dev.example
+++ b/env.dev.example
@@ -199,5 +199,4 @@ MCP_MAPBOX_ACCESS_TOKEN=
 #   dev instance: SEARCH_MCP_URL=https://dev-api.faktenforum.org/search/mcp  SEARCH_MCP_DOMAIN=dev-api.faktenforum.org
 SEARCH_MCP_URL=
 SEARCH_MCP_API_KEY=
-SEARCH_API_KEY=
 SEARCH_MCP_DOMAIN=

--- a/env.local.example
+++ b/env.local.example
@@ -285,5 +285,4 @@ MCP_MAPBOX_ACCESS_TOKEN=
 #   dev:  SEARCH_MCP_URL=https://dev-api.faktenforum.org/search/mcp  SEARCH_MCP_DOMAIN=dev-api.faktenforum.org
 SEARCH_MCP_URL=
 SEARCH_MCP_API_KEY=
-SEARCH_API_KEY=
 SEARCH_MCP_DOMAIN=

--- a/env.prod.example
+++ b/env.prod.example
@@ -193,5 +193,4 @@ MCP_MAPBOX_ACCESS_TOKEN=
 #   prod instance: SEARCH_MCP_URL=https://api.faktenforum.org/search/mcp  SEARCH_MCP_DOMAIN=api.faktenforum.org
 SEARCH_MCP_URL=
 SEARCH_MCP_API_KEY=
-SEARCH_API_KEY=
 SEARCH_MCP_DOMAIN=

--- a/scripts/setup-env.ts
+++ b/scripts/setup-env.ts
@@ -240,7 +240,6 @@ const PROMPTS: Record<string, PromptConfig> = {
     // Faktenforum Search (external MCP; optional)
     'SEARCH_MCP_URL': { message: 'Search MCP URL (optional; empty disables; e.g. https://dev-api.faktenforum.org/search/mcp):', type: 'input', defaultGen: () => '' },
     'SEARCH_MCP_API_KEY': { message: 'Search MCP API key (optional; must match external Search):', type: 'password', defaultGen: () => '' },
-    'SEARCH_API_KEY': { message: 'Search REST API key (optional; must match external Search):', type: 'password', defaultGen: () => '' },
     'SEARCH_MCP_DOMAIN': { message: 'Search MCP domain for allowlist (optional; e.g. dev-api.faktenforum.org):', type: 'input', defaultGen: () => '' },
 
     // Spend Monitor dashboard - Traefik basic auth (prod/dev). Generate: htpasswd -nbB admin <password>
@@ -263,7 +262,6 @@ const MIGRATIONS: Record<string, string> = {
     'PLAYWRIGHT_MICROSERVICE_URL': 'FIRECRAWL_PLAYWRIGHT_MICROSERVICE_URL',
     'CHECKBOT_RAG_MCP_URL': 'SEARCH_MCP_URL',
     'CHECKBOT_RAG_MCP_API_KEY': 'SEARCH_MCP_API_KEY',
-    'CHECKBOT_RAG_API_KEY': 'SEARCH_API_KEY',
     'CHECKBOT_RAG_MCP_DOMAIN': 'SEARCH_MCP_DOMAIN',
 };
 


### PR DESCRIPTION
## Summary

- `SEARCH_API_KEY` was added back when checkbot-rag was still a submodule of this repo, intended for a future REST call to Search's `GET /api/v1/search`. That integration was always meant to live in `faktenforum/faktenforum`, not here - and nothing in this repo ever consumed the var.
- Removed it from `env.local.example`, `env.dev.example`, `env.prod.example`, and its `setup-env.ts` prompt + migration alias.
- `SEARCH_MCP_API_KEY` (the actual MCP endpoint key, wired up in #72) is unaffected.

## Test plan

- [x] Confirmed no other reference to `SEARCH_API_KEY` remains in the repo (`librechat.yaml`, compose files, init scripts)

https://claude.ai/code/session_0132zBzKju1SMUVkqVvDg5iK