### PR TITLE
feat(mcp-image-gen): report generation cost and modernize the server

### DIFF
--- a/packages/librechat-init/config/agent-instructions/shared-agent-image-generation-instructions.md
+++ b/packages/librechat-init/config/agent-instructions/shared-agent-image-generation-instructions.md
@@ -4,7 +4,9 @@ Role: Image generation.
 
 Constraint: Before each generate_image call list_models; use only a model id from that response (never guess names).
 
-Workflow: list_models → pick id → (optional) check_model → build prompt (3–6 sentences: composition, lighting, style, colors) → generate_image → refine. Multiple images: suggest variations from list.
+Workflow: list_models → pick id → (optional) check_model → build prompt (3–6 sentences: composition, lighting, style, colors) → generate_image → review the returned image → refine. Multiple images: suggest variations from list.
+
+After generate_image the image is shown back to you. Briefly assess whether it matches the request (subject, composition, style, text/artifacts). If it clearly misses, say what is off and offer a refined prompt or another model; do not silently regenerate.
 
 {{include:conventions-when-unclear.md}}
 

--- a/packages/mcp-image-gen/package.json
+++ b/packages/mcp-image-gen/package.json
@@ -10,7 +10,7 @@
     "dev": "node --watch --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings src/server.ts",
     "dev:local": "dotenv -e ../../.env.local -- node --watch --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings src/server.ts",
     "lint": "eslint . --ext .ts",
-    "test": "echo \"Tests to be implemented\"",
+    "test": "node --experimental-strip-types --experimental-transform-types --no-warnings --test 'src/**/*.test.ts'",
     "test:integration": "./test/integration.ts",
     "test:integration:local": "dotenv -e ../../.env.local -- ./test/integration.ts",
     "test:http": "./test/http-test.ts",
@@ -20,12 +20,11 @@
     "validate": "tsc --noEmit"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
-    "axios": "^1.13.6",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "pino": "^10.3.1",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/packages/mcp-image-gen/src/config.ts
+++ b/packages/mcp-image-gen/src/config.ts
@@ -3,10 +3,16 @@
  * Environment variables are read at startup; missing required values cause exit(1).
  */
 
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { EXAMPLE_MODEL_ID } from './constants/models.ts';
 
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8'),
+) as { version: string };
+
 export const SERVER_NAME = 'image-generation-mcp-server';
-export const SERVER_VERSION = '1.0.0';
+export const SERVER_VERSION = pkg.version;
 
 export const PORT = parseInt(process.env.PORT ?? '3001', 10);
 export const OPENROUTER_API_KEY =

--- a/packages/mcp-image-gen/src/services/openrouter.test.ts
+++ b/packages/mcp-image-gen/src/services/openrouter.test.ts
@@ -1,0 +1,105 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { OpenRouterClient, extractImageUrl } from './openrouter.ts';
+
+const DATA_URL = 'data:image/png;base64,AAAB';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Stub fetch, capturing the request body sent to /chat/completions. */
+function stubFetch(responseBody: unknown): { lastBody: () => Record<string, unknown> } {
+  let captured: Record<string, unknown> = {};
+  globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    captured = init?.body ? JSON.parse(init.body as string) : {};
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+  return { lastBody: () => captured };
+}
+
+test('extractImageUrl: reads message.images[]', () => {
+  const url = extractImageUrl({
+    choices: [{ message: { images: [{ type: 'image_url', image_url: { url: DATA_URL } }] } }],
+  });
+  assert.equal(url, DATA_URL);
+});
+
+test('extractImageUrl: falls back to message.content[] image_url', () => {
+  const url = extractImageUrl({
+    choices: [{ message: { content: [{ type: 'image_url', image_url: { url: DATA_URL } }] } }],
+  });
+  assert.equal(url, DATA_URL);
+});
+
+test('extractImageUrl: wraps a bare base64 string as a data URL', () => {
+  const url = extractImageUrl({
+    choices: [{ message: { images: [{ type: 'image_url', image_url: { url: 'ABC123' } }] } }],
+  });
+  assert.equal(url, 'data:image/png;base64,ABC123');
+});
+
+test('extractImageUrl: throws when no image present', () => {
+  assert.throws(() => extractImageUrl({ choices: [{ message: {} }] }));
+});
+
+test('generateImage: extracts the provider cost from usage.cost', async () => {
+  stubFetch({
+    choices: [{ message: { images: [{ type: 'image_url', image_url: { url: DATA_URL } }] } }],
+    usage: { cost: 0.042 },
+  });
+  const client = new OpenRouterClient('test-key');
+  const result = await client.generateImage({
+    prompt: 'a red square',
+    model: 'black-forest-labs/flux.2-pro',
+  });
+  assert.equal(result.imageUrl, DATA_URL);
+  assert.equal(result.costUsd, 0.042);
+});
+
+test('generateImage: costUsd is undefined when no usage returned', async () => {
+  stubFetch({
+    choices: [{ message: { images: [{ type: 'image_url', image_url: { url: DATA_URL } }] } }],
+  });
+  const client = new OpenRouterClient('test-key');
+  const result = await client.generateImage({
+    prompt: 'a red square',
+    model: 'black-forest-labs/flux.2-pro',
+  });
+  assert.equal(result.costUsd, undefined);
+});
+
+test('generateImage: sends usage.include and image_config for a size-capable model', async () => {
+  const stub = stubFetch({
+    choices: [{ message: { images: [{ type: 'image_url', image_url: { url: DATA_URL } }] } }],
+    usage: { cost: 0.01 },
+  });
+  const client = new OpenRouterClient('test-key');
+  await client.generateImage({
+    prompt: 'a landscape',
+    model: 'google/gemini-2.5-flash-image',
+    aspect_ratio: '16:9',
+    image_size: '2K',
+  });
+  const body = stub.lastBody();
+  assert.deepEqual(body.usage, { include: true });
+  assert.deepEqual(body.image_config, { aspect_ratio: '16:9', image_size: '2K' });
+});
+
+test('generateImage: omits image_config for a model that supports neither option', async () => {
+  const stub = stubFetch({
+    choices: [{ message: { images: [{ type: 'image_url', image_url: { url: DATA_URL } }] } }],
+  });
+  const client = new OpenRouterClient('test-key');
+  await client.generateImage({
+    prompt: 'a red square',
+    model: 'black-forest-labs/flux.2-pro',
+    aspect_ratio: '16:9',
+    image_size: '2K',
+  });
+  assert.equal(stub.lastBody().image_config, undefined);
+});

--- a/packages/mcp-image-gen/src/services/openrouter.ts
+++ b/packages/mcp-image-gen/src/services/openrouter.ts
@@ -1,4 +1,3 @@
-import axios, { type AxiosInstance } from 'axios';
 import { logger } from '../utils/logger.ts';
 import { OpenRouterAPIError } from '../utils/errors.ts';
 import type { GenerateImageInput } from '../schemas/image-gen.schema.ts';
@@ -29,6 +28,14 @@ interface OpenRouterModelsResponse {
   data: OpenRouterModel[];
 }
 
+/** Usage block; `cost` (USD) is present when the request opts in via `usage.include`. */
+interface OpenRouterUsage {
+  cost?: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
 interface OpenRouterImageResponse {
   choices: Array<{
     message: {
@@ -40,6 +47,7 @@ interface OpenRouterImageResponse {
       }>;
     };
   }>;
+  usage?: OpenRouterUsage;
 }
 
 /** Request body for POST /chat/completions (image generation). */
@@ -49,28 +57,39 @@ interface ChatCompletionRequest {
   modalities?: string[];
   response_modalities?: string[];
   image_config?: { aspect_ratio?: string; image_size?: string };
+  usage?: { include: boolean };
 }
 
-// --- Helpers ------------------------------------------------------------------
+/** A generated image plus the provider cost, when OpenRouter reports one. */
+export interface GeneratedImage {
+  imageUrl: string;
+  /** Provider cost in USD (OpenRouter credits are 1:1 USD). Undefined if not reported. */
+  costUsd?: number;
+}
 
+const REQUEST_TIMEOUT_MS = 120_000;
 const NO_ENDPOINTS_PATTERN = /no endpoints found.*output modalities|modalities.*image/i;
 
-function extractImageFromResponse(response: {
-  data: OpenRouterImageResponse;
-}): string {
-  const message = response.data.choices?.[0]?.message;
-  let images = message?.images ?? [];
+/** Error carrying the HTTP status so callers can branch (e.g. no-endpoints 404 retry). */
+class OpenRouterHttpError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = 'OpenRouterHttpError';
+  }
+}
 
-  if (images.length === 0 && Array.isArray(message?.content)) {
-    const item = message.content.find(
-      (c) => c.type === 'image_url' && c.image_url?.url,
-    );
-    if (item?.image_url?.url) {
-      images = [{ type: 'image_url', image_url: { url: item.image_url.url } }];
-    }
+export function extractImageUrl(response: OpenRouterImageResponse): string {
+  const message = response.choices?.[0]?.message;
+  let url = message?.images?.[0]?.image_url?.url;
+
+  if (!url && Array.isArray(message?.content)) {
+    url = message.content.find((c) => c.type === 'image_url' && c.image_url?.url)
+      ?.image_url?.url;
   }
 
-  const url = images[0]?.image_url?.url;
   if (!url) {
     throw new OpenRouterAPIError(
       'No image data in OpenRouter response. The model may not support image generation or the request failed.',
@@ -84,90 +103,59 @@ function noEndpointMessage(modelId: string): string {
   return `Model "${modelId}" is not available for image generation on OpenRouter (no endpoint for image output). Use list_models or check_model to pick a supported model (e.g. ${EXAMPLE_MODEL_ID}).`;
 }
 
-function parseAxiosError(error: unknown): {
-  message: string;
-  status?: number;
-  isNoEndpoints404: boolean;
-} {
-  if (!axios.isAxiosError(error)) {
-    return {
-      message: error instanceof Error ? error.message : String(error),
-      isNoEndpoints404: false,
-    };
+function errorMessageFromBody(body: unknown, fallback: string): string {
+  if (typeof body === 'object' && body !== null && 'error' in body) {
+    const err = (body as { error?: { message?: string } }).error;
+    if (err?.message) {
+      return err.message;
+    }
   }
-  const data = error.response?.data ?? error.message;
-  const message =
-    typeof data === 'object' && data !== null && 'error' in data
-      ? String((data as { error?: { message?: string } }).error?.message ?? '')
-      : String(data);
-  const status = error.response?.status;
-  const isNoEndpoints404 =
-    status === 404 && NO_ENDPOINTS_PATTERN.test(message);
-  return { message, status, isNoEndpoints404 };
+  return fallback;
 }
 
 // --- Client -------------------------------------------------------------------
 
 export class OpenRouterClient {
-  private readonly client: AxiosInstance;
   private readonly baseUrl: string;
+  private readonly headers: Record<string, string>;
 
-  constructor(
-    apiKey: string,
-    baseUrl: string = 'https://openrouter.ai/api/v1',
-  ) {
+  constructor(apiKey: string, baseUrl: string = 'https://openrouter.ai/api/v1') {
     this.baseUrl = baseUrl.replace(/\/$/, '');
-    this.client = axios.create({
-      baseURL: this.baseUrl,
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-        'HTTP-Referer': 'https://librechat.ai',
-      },
-      timeout: 120_000,
-    });
+    this.headers = {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://librechat.ai',
+    };
   }
 
-  async generateImage(input: GenerateImageInput): Promise<string> {
+  async generateImage(input: GenerateImageInput): Promise<GeneratedImage> {
     const { prompt, model, aspect_ratio, image_size } = input;
 
     this.warnUnsupportedOptions(model, aspect_ratio, image_size);
 
-    const requestBody = this.buildRequestBody({
-      model,
-      prompt,
-      aspect_ratio,
-      image_size,
-    });
+    const requestBody = this.buildRequestBody({ model, prompt, aspect_ratio, image_size });
 
     logger.debug(
-      {
-        model,
-        modalities: requestBody.modalities ?? requestBody.response_modalities,
-      },
+      { model, modalities: requestBody.modalities ?? requestBody.response_modalities },
       'Generating image',
     );
 
     try {
-      const response = await this.client.post<OpenRouterImageResponse>(
-        '/chat/completions',
-        requestBody,
-      );
-      return extractImageFromResponse(response);
+      const response = await this.post<OpenRouterImageResponse>('/chat/completions', requestBody);
+      return this.toGeneratedImage(response);
     } catch (error) {
-      const { message, status, isNoEndpoints404 } = parseAxiosError(error);
+      const status = error instanceof OpenRouterHttpError ? error.status : undefined;
+      const message = error instanceof Error ? error.message : String(error);
+      const isNoEndpoints404 = status === 404 && NO_ENDPOINTS_PATTERN.test(message);
 
       if (isNoEndpoints404 && requestBody.modalities?.includes('text')) {
         logger.info({ model }, 'Retrying with modalities ["image"] only');
         requestBody.modalities = ['image'];
         try {
-          const retry = await this.client.post<OpenRouterImageResponse>(
-            '/chat/completions',
-            requestBody,
-          );
-          return extractImageFromResponse(retry);
+          const retry = await this.post<OpenRouterImageResponse>('/chat/completions', requestBody);
+          return this.toGeneratedImage(retry);
         } catch (retryErr) {
-          logger.error({ error: parseAxiosError(retryErr), model }, 'Retry failed');
+          logger.error({ error: String(retryErr), model }, 'Retry failed');
           throw new OpenRouterAPIError(noEndpointMessage(model), status);
         }
       }
@@ -176,24 +164,22 @@ export class OpenRouterClient {
       if (isNoEndpoints404) {
         throw new OpenRouterAPIError(noEndpointMessage(model), status);
       }
-      throw new OpenRouterAPIError(
-        `OpenRouter API error: ${typeof message === 'string' ? message : JSON.stringify(message)}`,
-        status,
-      );
+      if (error instanceof OpenRouterAPIError) {
+        throw error;
+      }
+      throw new OpenRouterAPIError(`OpenRouter API error: ${message}`, status);
     }
   }
 
   async listModels(): Promise<OpenRouterModel[]> {
     try {
-      const res = await this.client.get<OpenRouterModelsResponse>('/models');
-      return res.data.data ?? [];
+      const res = await this.get<OpenRouterModelsResponse>('/models');
+      return res.data ?? [];
     } catch (error) {
-      const { message, status } = parseAxiosError(error);
+      const status = error instanceof OpenRouterHttpError ? error.status : undefined;
+      const message = error instanceof Error ? error.message : String(error);
       logger.error({ error: message }, 'Error listing models');
-      throw new OpenRouterAPIError(
-        `OpenRouter API error: ${message}`,
-        status,
-      );
+      throw new OpenRouterAPIError(`OpenRouter API error: ${message}`, status);
     }
   }
 
@@ -201,9 +187,7 @@ export class OpenRouterClient {
     const all = await this.listModels();
     const knownIds = new Set(Object.keys(KNOWN_MODELS));
     return all.filter(
-      (m) =>
-        m.architecture?.output_modalities?.includes('image') ||
-        knownIds.has(m.id),
+      (m) => m.architecture?.output_modalities?.includes('image') || knownIds.has(m.id),
     );
   }
 
@@ -212,42 +196,79 @@ export class OpenRouterClient {
     supportsImageGeneration: boolean;
     details?: OpenRouterModel;
   }> {
-    try {
-      const models = await this.listModels();
-      const variations = this.normalizeModelId(modelId);
+    const models = await this.listModels();
+    const variations = this.normalizeModelId(modelId);
 
-      const model = this.findModel(models, modelId, variations);
-      const knownModel = this.findKnownModel(variations);
+    const model = this.findModel(models, modelId, variations);
+    const knownModel = this.findKnownModel(variations);
 
-      if (knownModel && !model) {
-        return {
-          exists: true,
-          supportsImageGeneration: true,
-          details: {
-            id: knownModel.id,
-            name: knownModel.name,
-            description: knownModel.description,
-            pricing: knownModel.pricing,
-          } as OpenRouterModel,
-        };
-      }
-
-      if (!model) {
-        return { exists: false, supportsImageGeneration: false };
-      }
-
-      const supportsImage =
-        (model.architecture?.output_modalities?.includes('image') ?? false) ||
-        knownModel !== undefined;
-
+    if (knownModel && !model) {
       return {
         exists: true,
-        supportsImageGeneration: supportsImage,
-        details: model,
+        supportsImageGeneration: true,
+        details: {
+          id: knownModel.id,
+          name: knownModel.name,
+          description: knownModel.description,
+          pricing: knownModel.pricing,
+        } as OpenRouterModel,
       };
+    }
+
+    if (!model) {
+      return { exists: false, supportsImageGeneration: false };
+    }
+
+    const supportsImage =
+      (model.architecture?.output_modalities?.includes('image') ?? false) ||
+      knownModel !== undefined;
+
+    return { exists: true, supportsImageGeneration: supportsImage, details: model };
+  }
+
+  private toGeneratedImage(response: OpenRouterImageResponse): GeneratedImage {
+    const imageUrl = extractImageUrl(response);
+    const costUsd =
+      typeof response.usage?.cost === 'number' ? response.usage.cost : undefined;
+    return { imageUrl, costUsd };
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>(path, { method: 'POST', body: JSON.stringify(body) });
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    return this.request<T>(path, { method: 'GET' });
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const res = await fetch(this.baseUrl + path, {
+        ...init,
+        headers: this.headers,
+        signal: controller.signal,
+      });
+      const text = await res.text();
+      const parsed: unknown = text ? JSON.parse(text) : undefined;
+      if (!res.ok) {
+        throw new OpenRouterHttpError(
+          errorMessageFromBody(parsed, text || res.statusText),
+          res.status,
+        );
+      }
+      return parsed as T;
     } catch (error) {
-      logger.error({ error, modelId }, 'Error checking model');
+      if (error instanceof OpenRouterHttpError) {
+        throw error;
+      }
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw new OpenRouterAPIError(`OpenRouter request timed out after ${REQUEST_TIMEOUT_MS}ms`);
+      }
       throw error;
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -272,12 +293,13 @@ export class OpenRouterClient {
   }): ChatCompletionRequest {
     const { model, prompt, aspect_ratio, image_size } = input;
     const modality = this.getModalityRequest(model);
-    const supportsAr = this.supportsAspectRatio(model);
-    const supportsSize = this.supportsImageSize(model);
+    const useAspectRatio = Boolean(aspect_ratio) && this.supportsAspectRatio(model);
+    const useImageSize = Boolean(image_size) && this.supportsImageSize(model);
 
     const body: ChatCompletionRequest = {
       model,
       messages: [{ role: 'user', content: prompt }],
+      usage: { include: true },
     };
 
     if (modality === 'response_modalities') {
@@ -288,10 +310,10 @@ export class OpenRouterClient {
       body.modalities = ['image', 'text'];
     }
 
-    if (supportsAr && (aspect_ratio || image_size)) {
+    if (useAspectRatio || useImageSize) {
       body.image_config = {};
-      if (aspect_ratio) body.image_config.aspect_ratio = aspect_ratio;
-      if (image_size && supportsSize) body.image_config.image_size = image_size;
+      if (useAspectRatio) body.image_config.aspect_ratio = aspect_ratio;
+      if (useImageSize) body.image_config.image_size = image_size;
     }
 
     return body;
@@ -321,10 +343,7 @@ export class OpenRouterClient {
     m = models.find((x) => x.id.toLowerCase() === lower);
     if (m) return m;
     for (const v of variations) {
-      m = models.find(
-        (x) =>
-          x.id === v || x.id.toLowerCase() === v.toLowerCase(),
-      );
+      m = models.find((x) => x.id === v || x.id.toLowerCase() === v.toLowerCase());
       if (m) return m;
     }
     return undefined;
@@ -334,9 +353,7 @@ export class OpenRouterClient {
     variations: string[],
   ): (typeof KNOWN_MODELS)[keyof typeof KNOWN_MODELS] | undefined {
     for (const v of variations) {
-      const key = Object.keys(KNOWN_MODELS).find(
-        (k) => k.toLowerCase() === v.toLowerCase(),
-      );
+      const key = Object.keys(KNOWN_MODELS).find((k) => k.toLowerCase() === v.toLowerCase());
       if (key) return KNOWN_MODELS[key as keyof typeof KNOWN_MODELS];
     }
     return undefined;

--- a/packages/mcp-image-gen/src/tools/image-gen.test.ts
+++ b/packages/mcp-image-gen/src/tools/image-gen.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { imageResultContent } from './image-gen.ts';
+
+const DATA_URL = 'data:image/png;base64,AAAB';
+
+test('imageResultContent: attaches cost to _meta when reported', () => {
+  const result = imageResultContent(DATA_URL, 0.0387, 'google/gemini-2.5-flash-image');
+  assert.equal(result.content[0]?.type, 'text');
+  assert.equal(result.content[1]?.type, 'image');
+  assert.deepEqual(result._meta, {
+    cost: { usd: 0.0387, model: 'google/gemini-2.5-flash-image', provider: 'openrouter' },
+  });
+});
+
+test('imageResultContent: no _meta when cost is undefined', () => {
+  const result = imageResultContent(DATA_URL, undefined, 'black-forest-labs/flux.2-pro');
+  assert.equal(result._meta, undefined);
+});
+
+test('imageResultContent: no _meta when cost is zero', () => {
+  const result = imageResultContent(DATA_URL, 0, 'black-forest-labs/flux.2-pro');
+  assert.equal(result._meta, undefined);
+});

--- a/packages/mcp-image-gen/src/tools/image-gen.ts
+++ b/packages/mcp-image-gen/src/tools/image-gen.ts
@@ -1,7 +1,8 @@
+import { z } from 'zod';
 import type { TextContent, ImageContent } from '@modelcontextprotocol/sdk/types.js';
 import { GenerateImageSchema, CheckModelSchema } from '../schemas/image-gen.schema.ts';
 import { OpenRouterClient } from '../services/openrouter.ts';
-import { InvalidInputError, ImageGenError } from '../utils/errors.ts';
+import { ImageGenError } from '../utils/errors.ts';
 import { logger } from '../utils/logger.ts';
 import { parseImageData } from '../utils/data-url.ts';
 import { KNOWN_MODELS, EXAMPLE_MODEL_ID } from '../constants/models.ts';
@@ -28,41 +29,63 @@ interface MergedModel {
 
 // --- generate_image ----------------------------------------------------------
 
+/** Tool result with optional out-of-band metadata (provider cost). */
+type ImageToolResult = {
+  content: Array<TextContent | ImageContent>;
+  _meta?: Record<string, unknown>;
+};
+
 export async function generateImage(
   input: unknown,
   openRouterClient: OpenRouterClient,
-): Promise<{ content: Array<TextContent | ImageContent> }> {
+): Promise<ImageToolResult> {
+  let parsed;
   try {
-    const parsed = GenerateImageSchema.parse(input);
-    logger.info(
-      { model: parsed.model, hasAspectRatio: !!parsed.aspect_ratio, hasImageSize: !!parsed.image_size },
-      'Generating image',
-    );
-
-    const imageUrl = await openRouterClient.generateImage(parsed);
-    return imageUrlToContent(imageUrl);
+    parsed = GenerateImageSchema.parse(input);
   } catch (error) {
-    if (error instanceof InvalidInputError) {
-      return { content: [{ type: 'text', text: `Error: ${error.message}` }] };
+    if (error instanceof z.ZodError) {
+      const detail = error.issues
+        .map((issue) => `${issue.path.join('.') || 'input'}: ${issue.message}`)
+        .join('; ');
+      return { content: [{ type: 'text', text: `Error: invalid input - ${detail}` }] };
     }
     throw error;
   }
+
+  logger.info(
+    { model: parsed.model, hasAspectRatio: !!parsed.aspect_ratio, hasImageSize: !!parsed.image_size },
+    'Generating image',
+  );
+
+  const { imageUrl, costUsd } = await openRouterClient.generateImage(parsed);
+  return imageResultContent(imageUrl, costUsd, parsed.model);
 }
 
-function imageUrlToContent(
+/**
+ * Builds the tool result and attaches the provider cost (when reported) under
+ * `_meta.cost`. LibreChat reads this to bill the generation against the user's
+ * balance; USD is used as the wire unit and converted downstream.
+ */
+export function imageResultContent(
   imageUrl: string,
-): { content: Array<TextContent | ImageContent> } {
+  costUsd: number | undefined,
+  model: string,
+): ImageToolResult {
   try {
     const { data, mimeType } = parseImageData(imageUrl);
     if (!data?.length) {
       throw new Error('Empty base64 data extracted from image URL');
     }
-    return {
+    const result: ImageToolResult = {
       content: [
         { type: 'text', text: 'Image generated successfully.' },
         { type: 'image', data, mimeType },
       ],
     };
+    if (typeof costUsd === 'number' && costUsd > 0) {
+      result._meta = { cost: { usd: costUsd, model, provider: 'openrouter' } };
+    }
+    return result;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.error(
@@ -214,8 +237,12 @@ export async function checkModel(
       ],
     };
   } catch (error) {
-    if (error instanceof InvalidInputError) {
-      return { content: [{ type: 'text', text: `Error: ${error.message}` }] };
+    if (error instanceof z.ZodError) {
+      return {
+        content: [
+          { type: 'text', text: `Error: invalid input - ${error.issues[0]?.message ?? 'model is required'}` },
+        ],
+      };
     }
     throw error;
   }

--- a/packages/mcp-image-gen/src/utils/data-url.test.ts
+++ b/packages/mcp-image-gen/src/utils/data-url.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseImageData } from './data-url.ts';
+
+test('parseImageData: data URL with mime + base64', () => {
+  const { data, mimeType } = parseImageData('data:image/png;base64,AAAB');
+  assert.equal(data, 'AAAB');
+  assert.equal(mimeType, 'image/png');
+});
+
+test('parseImageData: data URL with parameters before base64', () => {
+  const { data, mimeType } = parseImageData('data:image/webp;charset=utf-8;base64,ZZZ');
+  assert.equal(data, 'ZZZ');
+  assert.equal(mimeType, 'image/webp');
+});
+
+test('parseImageData: raw base64 defaults to image/png', () => {
+  const { data, mimeType } = parseImageData('QQQQ');
+  assert.equal(data, 'QQQQ');
+  assert.equal(mimeType, 'image/png');
+});
+
+test('parseImageData: malformed data URL throws', () => {
+  assert.throws(() => parseImageData('data:image/png,notbase64'));
+});

--- a/packages/mcp-image-gen/src/utils/errors.ts
+++ b/packages/mcp-image-gen/src/utils/errors.ts
@@ -17,23 +17,3 @@ export class OpenRouterAPIError extends ImageGenError {
   }
 }
 
-export class InvalidInputError extends ImageGenError {
-  constructor(message: string) {
-    super(message, 'INVALID_INPUT', true);
-    this.name = 'InvalidInputError';
-  }
-}
-
-export class ModelNotFoundError extends ImageGenError {
-  constructor(model: string) {
-    super(`Model not found: ${model}`, 'MODEL_NOT_FOUND', true);
-    this.name = 'ModelNotFoundError';
-  }
-}
-
-export class ValidationError extends ImageGenError {
-  constructor(message: string) {
-    super(message, 'VALIDATION_ERROR', true);
-    this.name = 'ValidationError';
-  }
-}

--- a/packages/mcp-image-gen/src/utils/tool-handler.ts
+++ b/packages/mcp-image-gen/src/utils/tool-handler.ts
@@ -2,7 +2,12 @@ import type { TextContent, ImageContent } from '@modelcontextprotocol/sdk/types.
 import { logger } from './logger.ts';
 import { ImageGenError } from './errors.ts';
 
-type ToolResult = { content: Array<TextContent | ImageContent>; isError?: boolean };
+type ToolResult = {
+  content: Array<TextContent | ImageContent>;
+  isError?: boolean;
+  /** Out-of-band metadata (e.g. provider cost) forwarded to the MCP client. */
+  _meta?: Record<string, unknown>;
+};
 
 export function withToolErrorHandler<TArgs extends unknown[], TResult extends ToolResult>(
   toolName: string,


### PR DESCRIPTION
## What

Modernizes the image-gen MCP server and makes it report its OpenRouter cost so LibreChat can bill image generation against a user's balance (the billing side is a separate LibreChat-fork PR).

### Cost reporting
- Sends `usage: { include: true }` and returns the per-generation cost under the tool result `_meta.cost` (`{ usd, model, provider }`). Verified against live OpenRouter: a `gemini-2.5-flash-image` generation reported `costUsd: 0.0387`.

### Modernization
- Drop `axios` for native `fetch` (Node 24) with `AbortController` timeout — one fewer dependency and its CVE surface.
- Bump `@modelcontextprotocol/sdk` → `^1.29`, `zod` → `^4.4.3`.
- Surface zod validation errors as friendly tool messages (previously fell through to "Unexpected error"); remove the dead `InvalidInputError` branch and unused error classes.
- Fix `image_size` being gated behind aspect-ratio support in the request body.
- Read `SERVER_VERSION` from `package.json` instead of a hardcoded `1.0.0`.

### Tests
- New `node:test` unit tests (data-url parsing, response image extraction, cost extraction, request-body gating, `_meta` wiring). 15 tests, `tsc --noEmit` clean.

### Agent
- The Image Generation agent now reviews the returned image (the vision model can see it after the companion agents fix) and offers refinements instead of silently regenerating.

## Notes
- Depends conceptually on the agents role-ordering fix (faktenforum/agents#2) for the vision model to actually see the image; independent at the code level.
- Billing consumer: separate LibreChat-fork PR reads `_meta.cost` and records a transaction.