### PR TITLE
chore(mcp): bump MCP SDK to 1.29 and override transitive security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,11 @@
         "@inquirer/prompts": "^8.3.2",
         "@types/node": "^25.5.0",
         "dotenv": "^17.3.1"
+    },
+    "overrides": {
+        "hono": "^4.12.27",
+        "@hono/node-server": "^1.19.14",
+        "express-rate-limit": "^8.5.2",
+        "fast-uri": "^3.1.3"
     }
 }

--- a/packages/mcp-calculator/package.json
+++ b/packages/mcp-calculator/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
-    "zod": "^4.3.6",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3",
     "express": "^5.2.1",
     "pino": "^10.3.1",
     "dotenv": "^17.3.1"

--- a/packages/mcp-chefkoch/package.json
+++ b/packages/mcp-chefkoch/package.json
@@ -17,12 +17,12 @@
     "test:http:local": "dotenv -e ../../.env.local -- ./test/http-test.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "cheerio": "^1.2.0",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "pino": "^10.3.1",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/packages/mcp-linux/package.json
+++ b/packages/mcp-linux/package.json
@@ -13,14 +13,14 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "busboy": "^1.6.0",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "js-yaml": "^4.1.1",
     "node-pty": "^1.1.0",
     "pino": "^10.3.1",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/busboy": "^1.5.4",

--- a/packages/mcp-ytptube/package.json
+++ b/packages/mcp-ytptube/package.json
@@ -13,9 +13,9 @@
     "validate": "tsc --noEmit"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@plussub/srt-vtt-parser": "^2.0.5",
-    "zod": "^4.3.6",
+    "zod": "^4.4.3",
     "express": "^5.2.1",
     "pino": "^10.3.1",
     "dotenv": "^17.3.1"

--- a/packages/spend-monitor/package.json
+++ b/packages/spend-monitor/package.json
@@ -10,12 +10,12 @@
     "lint": "eslint . --ext .ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "express": "^5.2.1",
     "mongodb": "^6.12.0",
     "pino": "^10.3.1",
     "dotenv": "^17.3.1",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",


### PR DESCRIPTION
## What

- Bump `@modelcontextprotocol/sdk` → `^1.29.0` and `zod` → `^4.4.3` across the MCP server packages: `mcp-calculator`, `mcp-chefkoch`, `mcp-linux`, `mcp-ytptube`, `spend-monitor`. (`mcp-image-gen` is bumped in its own modernization PR; `mcp-wikipedia` is a Python pip wrapper.)
- Add root `overrides` pinning the SDK's transitive dependencies to patched versions.

## Why

`npm audit` flagged four **high**-severity advisories in the SDK's transitive tree (`hono`, `@hono/node-server`, `express-rate-limit` → `ip-address`, `fast-uri`). All fixes are available as in-range patch bumps, so overriding them is low risk:

| package | override | fixes |
|---|---|---|
| `hono` | `^4.12.27` | JSX injection, serve-static path traversal |
| `@hono/node-server` | `^1.19.14` | serve-static auth bypass |
| `express-rate-limit` | `^8.5.2` | IPv4-mapped IPv6 rate-limit bypass (+ vulnerable `ip-address`) |
| `fast-uri` | `^3.1.3` | percent-encoded path traversal / host confusion |

Verified in a clean-room install (`@modelcontextprotocol/sdk@1.29` + these overrides): all four resolve to the patched versions and `npm audit` reports **0 vulnerabilities**. The overrides apply on fresh installs (CI/Docker build the images from scratch).

## Deferred

The risky **major** bumps flagged in the survey are intentionally left for a separate, tested change: `mcp-linux` `js-yaml` 4→5 and `spend-monitor` `mongodb` 6→7.