### PR TITLE
docs(env): name SEARCH_BOOTSTRAP_MCP_KEY as the required-identical counterpart

### DIFF
--- a/env.dev.example
+++ b/env.dev.example
@@ -198,5 +198,10 @@ MCP_MAPBOX_ACCESS_TOKEN=
 # omitted at init time. To enable, set the URL + API key plus the domain (MCP allowlist).
 #   dev instance: SEARCH_MCP_URL=https://dev-api.faktenforum.org/search/mcp  SEARCH_MCP_DOMAIN=dev-api.faktenforum.org
 SEARCH_MCP_URL=
+# Must be byte-for-byte identical to SEARCH_BOOTSTRAP_MCP_KEY on the Search deployment
+# (faktenforum-infrastructure dev.search.env.secret). Search seeds its "mcp-bootstrap"
+# key from that value and validates by SHA-256 hash, so any mismatch (or an empty value)
+# is rejected with 401 Unauthorized. The "env_mcp-" shown in the Search UI is a display
+# label only, not part of the key.
 SEARCH_MCP_API_KEY=
 SEARCH_MCP_DOMAIN=

--- a/env.local.example
+++ b/env.local.example
@@ -284,5 +284,9 @@ MCP_MAPBOX_ACCESS_TOKEN=
 #   prod: SEARCH_MCP_URL=https://api.faktenforum.org/search/mcp      SEARCH_MCP_DOMAIN=api.faktenforum.org
 #   dev:  SEARCH_MCP_URL=https://dev-api.faktenforum.org/search/mcp  SEARCH_MCP_DOMAIN=dev-api.faktenforum.org
 SEARCH_MCP_URL=
+# Must be byte-for-byte identical to SEARCH_BOOTSTRAP_MCP_KEY on the Search deployment.
+# Search seeds its "mcp-bootstrap" key from that value and validates by SHA-256 hash, so
+# any mismatch (or an empty value) is rejected with 401 Unauthorized. The "env_mcp-"
+# shown in the Search UI is a display label only, not part of the key.
 SEARCH_MCP_API_KEY=
 SEARCH_MCP_DOMAIN=

--- a/env.prod.example
+++ b/env.prod.example
@@ -192,5 +192,10 @@ MCP_MAPBOX_ACCESS_TOKEN=
 # omitted at init time. To enable, set the URL + API key plus the domain (MCP allowlist).
 #   prod instance: SEARCH_MCP_URL=https://api.faktenforum.org/search/mcp  SEARCH_MCP_DOMAIN=api.faktenforum.org
 SEARCH_MCP_URL=
+# Must be byte-for-byte identical to SEARCH_BOOTSTRAP_MCP_KEY on the Search deployment
+# (faktenforum-infrastructure prod.search.env.secret). Search seeds its "mcp-bootstrap"
+# key from that value and validates by SHA-256 hash, so any mismatch (or an empty value)
+# is rejected with 401 Unauthorized. The "env_mcp-" shown in the Search UI is a display
+# label only, not part of the key.
 SEARCH_MCP_API_KEY=
 SEARCH_MCP_DOMAIN=

--- a/scripts/setup-env.ts
+++ b/scripts/setup-env.ts
@@ -239,7 +239,7 @@ const PROMPTS: Record<string, PromptConfig> = {
 
     // Faktenforum Search (external MCP; optional)
     'SEARCH_MCP_URL': { message: 'Search MCP URL (optional; empty disables; e.g. https://dev-api.faktenforum.org/search/mcp):', type: 'input', defaultGen: () => '' },
-    'SEARCH_MCP_API_KEY': { message: 'Search MCP API key (optional; must match external Search):', type: 'password', defaultGen: () => '' },
+    'SEARCH_MCP_API_KEY': { message: 'Search MCP API key (optional; must equal SEARCH_BOOTSTRAP_MCP_KEY on the Search deployment, else 401):', type: 'password', defaultGen: () => '' },
     'SEARCH_MCP_DOMAIN': { message: 'Search MCP domain for allowlist (optional; e.g. dev-api.faktenforum.org):', type: 'input', defaultGen: () => '' },
 
     // Spend Monitor dashboard - Traefik basic auth (prod/dev). Generate: htpasswd -nbB admin <password>


### PR DESCRIPTION
## What

The Search MCP env docs never named the counterpart variable, so `SEARCH_MCP_API_KEY` (this stack) and `SEARCH_BOOTSTRAP_MCP_KEY` (the Search deployment) could silently drift apart.

- All three `env.*.example` files: comment on `SEARCH_MCP_API_KEY` now states it must be byte-for-byte identical to `SEARCH_BOOTSTRAP_MCP_KEY`, that Search validates by SHA-256 hash (so a mismatch or empty value is a 401), and that the `env_mcp-` shown in the Search UI is a display label, not part of the key.
- `scripts/setup-env.ts`: the prompt now names `SEARCH_BOOTSTRAP_MCP_KEY` instead of the vague "must match external Search".

## Why

A prod outage: prod-librechat logged repeated `[MCP][search] 401 Unauthorized` against `https://api.faktenforum.org/search/mcp`. Root cause was a typo in the prod `SEARCH_MCP_API_KEY` value, so its SHA-256 hash never matched the `mcp-bootstrap` key on the Search server. The OAuth-misdetect fix from #71/#72 is working; this was purely a shared-secret value mismatch. Naming the counterpart in the docs makes that class of typo obvious.

Docs only, no behaviour change.