### PR TITLE
fix(librechat): persist uploads on named volumes in prod and dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,9 +15,14 @@ services:
       LIBRECHAT_ENV: dev
       STACK_NAME: ${STACK_NAME:-prod}
     image: ghcr.io/faktenforum/librechat-init:dev
+    # Named volumes (not bind mounts) so uploads/images survive server rebuilds - they
+    # live on the attached docker-data volume like mongodata. Init runs as root and
+    # chowns them to UID:GID before the api container starts (see setup-permissions.ts).
     volumes:
       - librechat-config:/app/config
-      - ./images:/images
+      - librechat-images:/images
+      - librechat-uploads:/uploads
+      - librechat-logs:/logs
       - mongodata:/mongo_data
       - mongoconfig:/mongo_configdb
 
@@ -54,6 +59,13 @@ services:
     # gating, custom reranker) is baked into this image by the CI build
     # (.github/dockerfiles/librechat-with-agents.Dockerfile), so no host mount is needed.
     image: ghcr.io/faktenforum/librechat:dev
+    # Override the base bind mounts with named volumes so user uploads persist across
+    # server rebuilds (fileStrategy is local). Merged by container path over the base.
+    volumes:
+      - librechat-images:/app/client/public/images
+      - librechat-uploads:/app/uploads
+      - librechat-logs:/app/logs
+      - librechat-config:/app/config:ro
     depends_on:
       librechat-init:
         condition: service_completed_successfully
@@ -299,6 +311,12 @@ volumes:
     name: ${STACK_NAME:-prod}-pgdata2
   librechat-config:
     name: ${STACK_NAME:-prod}-librechat-config
+  librechat-images:
+    name: ${STACK_NAME:-prod}-librechat-images
+  librechat-uploads:
+    name: ${STACK_NAME:-prod}-librechat-uploads
+  librechat-logs:
+    name: ${STACK_NAME:-prod}-librechat-logs
   searxng-config:
     name: ${STACK_NAME:-prod}-searxng-config
   ytptube_config:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,9 +5,14 @@ services:
     image: ghcr.io/faktenforum/librechat-init:latest
     environment:
       STACK_NAME: ${STACK_NAME:-prod}
+    # Named volumes (not bind mounts) so uploads/images survive server rebuilds - they
+    # live on the attached docker-data volume like mongodata. Init runs as root and
+    # chowns them to UID:GID before the api container starts (see setup-permissions.ts).
     volumes:
       - librechat-config:/app/config
-      - ./images:/images
+      - librechat-images:/images
+      - librechat-uploads:/uploads
+      - librechat-logs:/logs
       - mongodata:/mongo_data
       - mongoconfig:/mongo_configdb
 
@@ -44,6 +49,13 @@ services:
     # gating, custom reranker) is baked into this image by the CI build
     # (.github/dockerfiles/librechat-with-agents.Dockerfile), so no host mount is needed.
     image: ghcr.io/faktenforum/librechat:latest
+    # Override the base bind mounts with named volumes so user uploads persist across
+    # server rebuilds (fileStrategy is local). Merged by container path over the base.
+    volumes:
+      - librechat-images:/app/client/public/images
+      - librechat-uploads:/app/uploads
+      - librechat-logs:/app/logs
+      - librechat-config:/app/config:ro
     depends_on:
       librechat-init:
         condition: service_completed_successfully
@@ -285,6 +297,12 @@ volumes:
     name: ${STACK_NAME:-prod}-pgdata2
   librechat-config:
     name: ${STACK_NAME:-prod}-librechat-config
+  librechat-images:
+    name: ${STACK_NAME:-prod}-librechat-images
+  librechat-uploads:
+    name: ${STACK_NAME:-prod}-librechat-uploads
+  librechat-logs:
+    name: ${STACK_NAME:-prod}-librechat-logs
   searxng-config:
     name: ${STACK_NAME:-prod}-searxng-config
   ytptube_config:


### PR DESCRIPTION
## What

Switch the LibreChat `api` and `librechat-init` upload paths (`/app/uploads`, `/app/client/public/images`, `/app/logs`) from host bind mounts to named volumes in the prod and dev stacks.

## Why

`fileStrategy` is `local`, so uploaded files are written to disk. They were bind-mounted under the project directory on the server root disk, while data like chat history (`mongodata`) lives on the attached docker-data volume (`/mnt/docker-data`, Docker `data-root`). On the recent server migration the named volumes came across but the bind mounts on the root disk did not, so user uploads were lost.

Named volumes land on the attached docker-data volume and survive server rebuilds, same as chat history. This mirrors the existing bind-to-named override already used for `mongodb` (`./data-node` becomes `mongodata`).

## Scope

- prod and dev only. `local` / `local-dev` keep bind mounts for host inspection.
- `librechat-init` runs as root and chowns the new volumes to UID:GID before `api` starts (`setup-permissions.ts`).

## Deploy note

Takes effect on stack redeploy. New volumes start empty (already-lost uploads stay lost); uploads made afterwards persist on the attached docker-data volume.

Verified with `docker compose config`: the three paths resolve to `type: volume` in both prod and dev, no bind mounts remain.
