### PR TITLE
feat(agents): make Faktencheck Assistant public for all users

### DIFF
--- a/packages/librechat-init/config/agents.yaml
+++ b/packages/librechat-init/config/agents.yaml
@@ -154,10 +154,10 @@ agents:
       - agent: shared-agent-assistant
         description: "Return to the Assistant when the request is outside fact-checking (e.g. general research, coding, documents). Do not hand back merely because the request is ambiguous; ask one short clarifying question or handle it within your role."
     recursion_limit: 25
-    isCollaborative: false # Not yet public
+    isCollaborative: true
     permissions:
-      public: false # Not yet public
-      publicEdit: false # Not yet public
+      public: true
+      publicEdit: false # everyone can use it, only owner can edit its config
 
   - id: shared-agent-image-generation
     name: Image Generation Assistant


### PR DESCRIPTION
Makes the **Faktencheck Assistant** public so every user can use it (it was `public: false` / "Not yet public").

## Change

In `packages/librechat-init/config/agents.yaml`, `shared-agent-faktencheck`:
- `permissions.public: false -> true` (grants public **VIEW** access → usable by all)
- `publicEdit: false` (kept) → users can use it, only the owner edits its config
- `isCollaborative: false -> true` (aligns with the other public agents)

## How it applies

`librechat-post-init` re-grants ACL permissions from this yaml on every run (`init-agents.ts` `buildPermissions` → `updateAgentPermissions`), so this takes effect on the next **librechat-init image** rebuild + redeploy. No manual DB change needed going forward.

Note: the other three public agents (Assistant, Image Generation, Travel and Location) are `publicEdit: true` (public EDIT). Faktencheck is intentionally public **VIEW** only — say if you want full parity and I'll flip `publicEdit` too.