### PR TITLE
feat(librechat): prioritize the default Assistant spec on every new chat

### DIFF
--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -358,7 +358,7 @@ endpoints:
 #
 # ==========================================
 modelSpecs:
-  prioritize: false  # avoids API warning when default spec + interface.presets are both enabled
+  prioritize: true  # force the default spec (Assistant) as the selection on every new chat, over a user's last-used model; emits a harmless startup warning alongside interface.presets
   list:
     # Assistants: agent specs; post-init patches preset.agent_id to real API id — restart API to apply. Assistant = default.
     # groupIcon is repeated on every spec: the menu takes the icon from the first *visible* spec, and specs whose


### PR DESCRIPTION
Makes the general **Assistant** the pre-selected default on every new chat.

## Change

`packages/librechat-init/config/librechat.yaml`: `modelSpecs.prioritize: false -> true`.

The `assistant-agent` spec is already `default: true` (+ `order: 0`), but with `prioritize: false` LibreChat only used it for fresh sessions and otherwise remembered a user's last-used model. `prioritize: true` forces the default spec as the selection on every new chat.

## Trade-off

The flag was deliberately `false` to avoid a startup API warning when `interface.presets: true` is also set. That warning is harmless log noise, not an error - accepted here in exchange for the forced default.

Applies on the next librechat-init image rebuild + redeploy.