### PR TITLE
fix(mcp): stop the GitHub server demanding OAuth; feat(spend-monitor): editable org budget

### DIFF
--- a/docker-compose.spend-monitor.yml
+++ b/docker-compose.spend-monitor.yml
@@ -17,7 +17,10 @@ services:
       # connects to the same database LibreChat uses, in every environment.
       SPEND_MONITOR_MONGO_URI: ${LIBRECHAT_MONGO_URI:-mongodb://${STACK_NAME:-prod}-mongodb:27017/LibreChat}
       SPEND_MONITOR_DB: ${SPEND_MONITOR_DB:-LibreChat}
+      # Budget and period are defaults only: the dashboard writes runtime overrides into
+      # the monitor's own state collection, which win over these. See docs/SPEND_MONITOR.md.
       SPEND_MONITOR_BUDGET_USD: ${SPEND_MONITOR_BUDGET_USD:-100}
+      # calendar-month | calendar-week | rolling-30d | rolling-7d
       SPEND_MONITOR_PERIOD: ${SPEND_MONITOR_PERIOD:-calendar-month}
       SPEND_MONITOR_WARN_PCT: ${SPEND_MONITOR_WARN_PCT:-50}
       SPEND_MONITOR_CRIT_PCT: ${SPEND_MONITOR_CRIT_PCT:-80}

--- a/docs/SPEND_MONITOR.md
+++ b/docs/SPEND_MONITOR.md
@@ -3,8 +3,8 @@
 Org-wide cost monitor for LibreChat. It aggregates spend from the `transactions`
 collection in LibreChat's MongoDB and serves an in-platform status page.
 
-**Reads only, apart from two explicit admin actions:** resetting one user's limit and
-lifting an org freeze. Optionally it enforces an org-wide hard cap by zeroing user
+**Reads only, apart from explicit admin actions:** changing the org budget or period,
+resetting one user's limit, and lifting an org freeze. Optionally it enforces an org-wide hard cap by zeroing user
 balances when spend reaches 100% of the budget (`SPEND_MONITOR_ENFORCE`).
 Per-user limits are defined by LibreChat's own `balance` config either way — the monitor
 displays them and can hand a single user their allowance back early.
@@ -16,6 +16,7 @@ A Scaleway billing webhook and email/webhook alerts are possible later phases.
 - `GET /health` — liveness
 - `GET /api/spend` — current-period spend JSON (org total, per-provider, per-model, per-user)
 - `GET /` — HTML status page (auto-refreshes every 30s)
+- `POST /settings` — change the org budget / accounting period (see [Changing the budget](#changing-the-budget-and-period))
 - `POST /users/:id/reset` — reset one user's limit (see [Per-user limits](#per-user-limits))
 - `POST /restore` — lift enforcement and restore balances (only when enforce is `on`/`dry-run`)
 - `POST /mcp` — MCP endpoint (admin-gated; see [MCP endpoint](#mcp-endpoint))
@@ -29,13 +30,41 @@ LibreChat writes one `transactions` row per spend. Convention: **1,000,000 token
 - matches `createdAt >= periodStart` and `tokenType in ['prompt','completion']` (refills, `tokenType: 'credits'`, are excluded)
 - org spend USD = `-sum(tokenValue) / 1_000_000`
 - provider split: model ids containing `/` are OpenRouter, bare ids are Scaleway
-- period: calendar month (default) or rolling 30 days
+- period: calendar month (default), calendar week, or a rolling 30/7-day window
 
 Spend is recorded after a completion, so the total trails real spend by at most the in-flight requests since the last poll. This is a monitor, not a hard cap.
 
-The banner also shows when the org counter restarts: the first of the next UTC month for
-`calendar-month`, and nothing for `rolling-30d` — that window slides continuously instead
-of resetting.
+The banner also shows when the org counter restarts. `calendar-month` restarts on the 1st and
+`calendar-week` on Monday (UTC, ISO weeks); the `rolling-*` windows slide continuously and
+never reset, so nothing is shown for them.
+
+## Changing the budget and period
+
+`SPEND_MONITOR_BUDGET_USD` and `SPEND_MONITOR_PERIOD` are **defaults**, not the last word.
+The dashboard's **Budget** section edits both at runtime and the override is stored in the
+monitor's own `spendmonitor_state` collection, so it survives a restart and needs no
+redeploy. Each field shows whether it is currently overridden, and the tooltip names the
+environment default it would fall back to; **Use env defaults** drops both overrides.
+
+Same thing over HTTP, and via the `set_org_budget` MCP tool:
+
+```bash
+curl -X POST http://spend.localhost/settings \
+  -H 'Content-Type: application/json' \
+  -d '{"budgetUsd": 250, "period": "calendar-week"}'
+
+# drop the overrides again
+curl -X POST http://spend.localhost/settings \
+  -H 'Content-Type: application/json' -d '{"budgetUsd": null, "period": null}'
+```
+
+Periods: `calendar-month` (default), `calendar-week`, `rolling-30d`, `rolling-7d`.
+
+**With `SPEND_MONITOR_ENFORCE=on` this is a live switch, in both directions.** Lowering the
+budget below current spend freezes every user immediately — the response reports
+`frozen: true, enforcementChanged: true` rather than predicting it, and the dashboard says
+so in a dialog. Raising it back above spend lifts the freeze and restores the snapshotted
+balances on the same request.
 
 ## Per-user limits
 
@@ -70,8 +99,8 @@ Amounts are USD; LibreChat stores credits (`1,000,000 credits = $1`). The org-wi
 | Var | Default | Meaning |
 |-----|---------|---------|
 | `SPEND_MONITOR_PORT` | `3016` | port (host + container) |
-| `SPEND_MONITOR_BUDGET_USD` | `100` | monthly org budget (set the real figure) |
-| `SPEND_MONITOR_PERIOD` | `calendar-month` | `calendar-month` or `rolling-30d` |
+| `SPEND_MONITOR_BUDGET_USD` | `100` | org budget default; overridable at runtime |
+| `SPEND_MONITOR_PERIOD` | `calendar-month` | `calendar-month`, `calendar-week`, `rolling-30d`, `rolling-7d`; overridable at runtime |
 | `SPEND_MONITOR_WARN_PCT` | `50` | warn threshold (%) |
 | `SPEND_MONITOR_CRIT_PCT` | `80` | critical threshold (%) |
 | `SPEND_MONITOR_EUR_RATE` | `0.92` | EUR per USD, display only |
@@ -101,6 +130,9 @@ Tools:
 - `reset_user_limit` (`email`, `confirm: true`, optional `credits_usd`) — same effect as a
   row's Reset button. Takes the login email rather than an id, and `credits_usd` overrides
   the default (the user's own refill amount).
+- `set_org_budget` (`confirm: true`, optional `budget_usd` / `period`, or `reset: true`) —
+  same effect as the dashboard's Budget form. Reports what the change actually did, including
+  whether it froze or unfroze the org.
 
 **Access control.** YAML-defined MCP servers are global in LibreChat (`chatMenu: false`
 only hides a server from the chat picker; any agent can still attach it), so the endpoint

--- a/env.dev.example
+++ b/env.dev.example
@@ -50,6 +50,9 @@ GOOGLE_KEY=
 # Spend Monitor (org cost dashboard + per-user limit resets; reuses LibreChat's MongoDB)
 # set your monthly org budget in USD
 SPEND_MONITOR_BUDGET_USD=100
+# Accounting window: calendar-month | calendar-week | rolling-30d | rolling-7d.
+# Both this and the budget are defaults - the dashboard can override them at runtime
+# (stored in the DB, survives restarts). See docs/SPEND_MONITOR.md.
 SPEND_MONITOR_PERIOD=calendar-month
 SPEND_MONITOR_WARN_PCT=50
 SPEND_MONITOR_CRIT_PCT=80

--- a/env.local.example
+++ b/env.local.example
@@ -175,6 +175,9 @@ MCP_IMAGE_GEN_LOG_LEVEL=info
 SPEND_MONITOR_PORT=3016
 SPEND_MONITOR_LOG_LEVEL=info
 SPEND_MONITOR_BUDGET_USD=100
+# Accounting window: calendar-month | calendar-week | rolling-30d | rolling-7d.
+# Both this and the budget are defaults - the dashboard can override them at runtime
+# (stored in the DB, survives restarts). See docs/SPEND_MONITOR.md.
 SPEND_MONITOR_PERIOD=calendar-month
 SPEND_MONITOR_WARN_PCT=50
 SPEND_MONITOR_CRIT_PCT=80

--- a/env.prod.example
+++ b/env.prod.example
@@ -43,6 +43,9 @@ GOOGLE_KEY=
 # Spend Monitor (org cost dashboard + per-user limit resets; reuses LibreChat's MongoDB)
 # set your monthly org budget in USD
 SPEND_MONITOR_BUDGET_USD=100
+# Accounting window: calendar-month | calendar-week | rolling-30d | rolling-7d.
+# Both this and the budget are defaults - the dashboard can override them at runtime
+# (stored in the DB, survives restarts). See docs/SPEND_MONITOR.md.
 SPEND_MONITOR_PERIOD=calendar-month
 SPEND_MONITOR_WARN_PCT=50
 SPEND_MONITOR_CRIT_PCT=80

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -943,6 +943,16 @@ mcpServers:
     iconPath: /images/mcp-github-icon.svg
     headers:
       Authorization: "Bearer ${MCP_GITHUB_PAT}"
+    # Static machine-user PAT, not OAuth - same reason as the `search` server below.
+    # Without this, LibreChat probes the URL without the Authorization header, gets a 401 +
+    # WWW-Authenticate from GitHub and records `OAuth Required: true`. Every tool call then
+    # tries a per-user OAuth flow instead of using the PAT above, and GitHub's auth server
+    # has no dynamic client registration, so the flow cannot even start:
+    #   Failed to initiate OAuth flow: Incompatible auth server: does not support
+    #   dynamic client registration
+    #   [MCP][github][pull_request_read] Error calling MCP tool: OAuth authentication failed
+    # An explicit value short-circuits the probe (see UserConnectionManager.ts).
+    requiresOAuth: false
     initTimeout: 120000
     chatMenu: true
     startup: true

--- a/packages/spend-monitor/README.md
+++ b/packages/spend-monitor/README.md
@@ -12,6 +12,7 @@ when over budget (`SPEND_MONITOR_ENFORCE`). Per-user limits are LibreChat's own
 - `GET /health` — liveness, `{status:"ok"}`
 - `GET /api/spend` — current-period spend JSON (org total, per-provider, per-model, per-user)
 - `GET /` — HTML status page (auto-refreshes every `SPEND_MONITOR_POLL_SECONDS`)
+- `POST /settings` — change the org budget / accounting period at runtime
 - `POST /users/:id/reset` — set one user's balance back to their configured refill amount
 - `POST /restore` — lift an active freeze and restore balances
 
@@ -22,8 +23,8 @@ when over budget (`SPEND_MONITOR_ENFORCE`). Per-user limits are LibreChat's own
 | `PORT` | `3016` | listen port |
 | `SPEND_MONITOR_MONGO_URI` | `mongodb://prod-mongodb:27017/LibreChat` | LibreChat MongoDB |
 | `SPEND_MONITOR_DB` | `LibreChat` | database name |
-| `SPEND_MONITOR_BUDGET_USD` | `100` | monthly org budget (USD) |
-| `SPEND_MONITOR_PERIOD` | `calendar-month` | `calendar-month` or `rolling-30d` |
+| `SPEND_MONITOR_BUDGET_USD` | `100` | org budget (USD); a runtime override in the DB wins |
+| `SPEND_MONITOR_PERIOD` | `calendar-month` | `calendar-month`, `calendar-week`, `rolling-30d`, `rolling-7d`; a runtime override wins |
 | `SPEND_MONITOR_WARN_PCT` | `50` | warn threshold (%) |
 | `SPEND_MONITOR_CRIT_PCT` | `80` | critical threshold (%) |
 | `SPEND_MONITOR_EUR_RATE` | `0.92` | EUR per USD, display only |
@@ -33,6 +34,14 @@ when over budget (`SPEND_MONITOR_ENFORCE`). Per-user limits are LibreChat's own
 Spend uses LibreChat's convention: `1,000,000 token credits = 1 USD`. `tokenValue`
 is negative for usage; `tokenType: 'credits'` rows (refills) are excluded.
 Provider split: model ids containing `/` are OpenRouter, bare ids are Scaleway.
+
+## Org budget and period
+
+Both env vars above are defaults. `POST /settings` (dashboard form, or the `set_org_budget`
+MCP tool) stores an override in `spendmonitor_state`, so the figure survives restarts and
+changes without a redeploy; posting `null` for a field drops the override. With
+`SPEND_MONITOR_ENFORCE=on` the change takes effect immediately in both directions - a budget
+below current spend freezes every user on the spot, and raising it back restores them.
 
 ## Per-user limits
 

--- a/packages/spend-monitor/src/aggregate.ts
+++ b/packages/spend-monitor/src/aggregate.ts
@@ -31,19 +31,41 @@ export interface Snapshot {
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+/** Days since the most recent Monday, in UTC (ISO weeks start Monday; getUTCDay puts Sunday at 0). */
+function daysSinceMonday(now: Date): number {
+  return (now.getUTCDay() + 6) % 7;
+}
+
+function startOfUtcDay(now: Date, offsetDays = 0): Date {
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - offsetDays),
+  );
+}
+
 export function periodStart(period: Period, now: Date): Date {
-  if (period === 'rolling-30d') {
-    return new Date(now.getTime() - 30 * MS_PER_DAY);
+  switch (period) {
+    case 'rolling-30d':
+      return new Date(now.getTime() - 30 * MS_PER_DAY);
+    case 'rolling-7d':
+      return new Date(now.getTime() - 7 * MS_PER_DAY);
+    case 'calendar-week':
+      return startOfUtcDay(now, daysSinceMonday(now));
+    case 'calendar-month':
+      return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
   }
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 }
 
 /** Next instant the period counter restarts. Rolling windows never restart - they slide. */
 export function periodResetAt(period: Period, now: Date): Date | null {
-  if (period === 'rolling-30d') {
-    return null;
+  switch (period) {
+    case 'rolling-30d':
+    case 'rolling-7d':
+      return null;
+    case 'calendar-week':
+      return startOfUtcDay(now, daysSinceMonday(now) - 7);
+    case 'calendar-month':
+      return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
   }
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
 }
 
 export function levelFor(ratio: number, warnPct: number, critPct: number): Level {

--- a/packages/spend-monitor/src/config.ts
+++ b/packages/spend-monitor/src/config.ts
@@ -1,7 +1,19 @@
 import 'dotenv/config';
 import type { EnforceMode } from './enforce.ts';
 
-export type Period = 'calendar-month' | 'rolling-30d';
+/**
+ * Accounting window for the org counter. `calendar-*` restarts on a boundary (so the
+ * counter resets and the number is comparable to an invoice); `rolling-*` slides and never
+ * resets. Weeks start Monday, in UTC like everything else here.
+ */
+export const PERIODS = [
+  'calendar-month',
+  'calendar-week',
+  'rolling-30d',
+  'rolling-7d',
+] as const;
+
+export type Period = (typeof PERIODS)[number];
 
 export interface Config {
   /** off (monitor only) | dry-run (log what it would do) | on (zero balances over budget) */
@@ -25,8 +37,12 @@ function num(name: string, def: number): number {
   return Number.isFinite(n) ? n : def;
 }
 
+function period(name: string, def: Period): Period {
+  const raw = process.env[name]?.trim();
+  return raw != null && (PERIODS as readonly string[]).includes(raw) ? (raw as Period) : def;
+}
+
 export function loadConfig(): Config {
-  const rawPeriod = process.env.SPEND_MONITOR_PERIOD;
   const rawEnforce = process.env.SPEND_MONITOR_ENFORCE;
   return {
     enforce: rawEnforce === 'on' ? 'on' : rawEnforce === 'dry-run' ? 'dry-run' : 'off',
@@ -34,7 +50,7 @@ export function loadConfig(): Config {
     mongoUri: process.env.SPEND_MONITOR_MONGO_URI || 'mongodb://prod-mongodb:27017/LibreChat',
     dbName: process.env.SPEND_MONITOR_DB || 'LibreChat',
     budgetUsd: num('SPEND_MONITOR_BUDGET_USD', 100),
-    period: rawPeriod === 'rolling-30d' ? 'rolling-30d' : 'calendar-month',
+    period: period('SPEND_MONITOR_PERIOD', 'calendar-month'),
     warnPct: num('SPEND_MONITOR_WARN_PCT', 50),
     critPct: num('SPEND_MONITOR_CRIT_PCT', 80),
     eurRate: num('SPEND_MONITOR_EUR_RATE', 0.92),

--- a/packages/spend-monitor/src/mcp.ts
+++ b/packages/spend-monitor/src/mcp.ts
@@ -15,6 +15,9 @@ import type { Snapshot } from './aggregate.ts';
 import type { EnforceState } from './enforce.ts';
 import { restoreBalances } from './enforce.ts';
 import { findUserIdByEmail, resetUserLimit } from './users.ts';
+import { effectiveConfig, updateSettings } from './settings.ts';
+import { PERIODS } from './config.ts';
+import type { Period } from './config.ts';
 import { renderMcpUi } from './page.ts';
 import { logger } from './utils/logger.ts';
 
@@ -25,7 +28,8 @@ const SERVER_VERSION = '1.0.0';
 export interface McpDeps {
   getSnapshot: () => Snapshot | null;
   getEnforceState: () => EnforceState;
-  refresh: () => Promise<void>;
+  /** Re-aggregates and applies enforcement; resolves true when the freeze state flipped. */
+  refresh: () => Promise<boolean>;
   cfg: Config;
   db: Db;
 }
@@ -47,7 +51,8 @@ function createMcpServer(deps: McpDeps): McpServer {
         'Org-wide LibreChat spend monitor (admins only). get_usage_report returns the current ' +
         'spend dashboard as an interactive UI resource - place its marker (\\ui{id}) in your reply. ' +
         'restore_balances lifts an active spending freeze and restores user balances. ' +
-        'reset_user_limit gives one user their per-period allowance back immediately.',
+        'reset_user_limit gives one user their per-period allowance back immediately. ' +
+        'set_org_budget changes the org-wide budget and accounting period without a redeploy.',
     },
   );
 
@@ -70,6 +75,7 @@ function createMcpServer(deps: McpDeps): McpServer {
           return textResult({ error: 'No spend data available yet. Try again shortly.' }, true);
         }
         const enforcement = deps.getEnforceState();
+        const effective = await effectiveConfig(deps.db, deps.cfg);
         const summary = {
           period: snap.period,
           period_start: snap.periodStart,
@@ -81,6 +87,12 @@ function createMcpServer(deps: McpDeps): McpServer {
           eur: snap.eur,
           enforce: deps.cfg.enforce,
           enforcement: { active: enforcement.active, since: enforcement.since, reason: enforcement.reason },
+          settings: {
+            budget_usd: effective.budgetUsd,
+            period: effective.period,
+            overridden: effective.overridden,
+            env_defaults: { budget_usd: deps.cfg.budgetUsd, period: deps.cfg.period },
+          },
           by_provider: snap.byProvider,
           top_users: snap.users.slice(0, 5).map((u) => ({
             email: u.email,
@@ -94,7 +106,10 @@ function createMcpServer(deps: McpDeps): McpServer {
         return {
           content: [
             { type: 'text' as const, text: JSON.stringify(summary, null, 2) },
-            uiResource('ui://spend-monitor/report', renderMcpUi(snap, deps.cfg.enforce, enforcement)),
+            uiResource(
+              'ui://spend-monitor/report',
+              renderMcpUi(snap, deps.cfg.enforce, enforcement, effective, deps.cfg),
+            ),
           ],
         };
       } catch (error) {
@@ -180,6 +195,71 @@ function createMcpServer(deps: McpDeps): McpServer {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         logger.error({ error: message, email: args.email }, 'reset_user_limit failed');
+        return textResult({ error: message }, true);
+      }
+    },
+  );
+
+  server.registerTool(
+    'set_org_budget',
+    {
+      description:
+        'Change the org-wide spend budget and/or the accounting period without a redeploy. ' +
+        'Pass budget_usd and/or period; pass reset: true to drop the overrides and fall back to ' +
+        'the deployment defaults. Requires confirm: true. Lowering the budget below current ' +
+        'spend freezes every user on the next poll when enforcement is on.',
+      inputSchema: {
+        confirm: z.boolean().describe('Must be true to write the new settings'),
+        budget_usd: z.number().positive().optional().describe('New org budget in USD'),
+        period: z
+          .enum(PERIODS)
+          .optional()
+          .describe('Accounting window: calendar-month, calendar-week, rolling-30d or rolling-7d'),
+        reset: z
+          .boolean()
+          .optional()
+          .describe('Drop both overrides and use the deployment defaults again'),
+      },
+    },
+    async (args) => {
+      try {
+        if (!args.confirm) {
+          return textResult({ error: 'Must pass confirm: true to change the budget.' }, true);
+        }
+        const reset = args.reset === true;
+        if (!reset && args.budget_usd == null && args.period == null) {
+          return textResult(
+            { error: 'Nothing to change: pass budget_usd and/or period, or reset: true.' },
+            true,
+          );
+        }
+        const applied = await updateSettings(
+          deps.db,
+          deps.cfg,
+          reset
+            ? { budgetUsd: null, period: null }
+            : {
+                ...(args.budget_usd != null ? { budgetUsd: args.budget_usd } : {}),
+                ...(args.period != null ? { period: args.period as Period } : {}),
+              },
+          'mcp',
+        );
+        const enforcementChanged = await deps.refresh();
+        const snap = deps.getSnapshot();
+        return textResult({
+          budget_usd: applied.budgetUsd,
+          period: applied.period,
+          overridden: applied.overridden,
+          level: snap?.level,
+          spent_usd: snap?.spentUsd,
+          period_reset_at: snap?.periodResetAt,
+          /** What the change actually did, not a prediction. */
+          frozen: deps.getEnforceState().active,
+          enforcement_changed: enforcementChanged,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error({ error: message }, 'set_org_budget failed');
         return textResult({ error: message }, true);
       }
     },

--- a/packages/spend-monitor/src/page.ts
+++ b/packages/spend-monitor/src/page.ts
@@ -1,5 +1,8 @@
 import type { Level, Snapshot } from './aggregate.ts';
 import type { EnforceMode, EnforceState } from './enforce.ts';
+import type { Config } from './config.ts';
+import { PERIODS } from './config.ts';
+import type { EffectiveConfig } from './settings.ts';
 
 const COLORS: Record<Level, { bg: string; fg: string; label: string }> = {
   ok: { bg: '#065f46', fg: '#d1fae5', label: 'OK' },
@@ -76,6 +79,12 @@ const STYLES = `
   td:last-child, th:last-child { text-align: right; }
   td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
   .muted { color: #6b7280; }
+  .settings { display: flex; flex-wrap: wrap; align-items: flex-end; gap: 0.75rem; margin-top: 0.5rem; }
+  .settings label { display: block; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: #9ca3af; margin-bottom: 0.2rem; }
+  .settings input, .settings select { background: #111827; color: #e5e7eb; border: 1px solid #374151; border-radius: 6px; padding: 0.35rem 0.5rem; font: inherit; font-size: 0.85rem; }
+  .settings input { width: 8rem; font-variant-numeric: tabular-nums; }
+  .badge { display: inline-block; font-size: 0.7rem; padding: 0.05rem 0.4rem; border-radius: 999px; background: #1f2937; color: #9ca3af; margin-left: 0.4rem; }
+  .badge.on { background: #1e3a8a; color: #bfdbfe; }
   .due { color: #fbbf24; }
   section h2 .hint { text-transform: none; letter-spacing: 0; font-weight: 400; }
   section { margin-top: 1.75rem; }
@@ -83,6 +92,30 @@ const STYLES = `
   footer { margin-top: 2rem; font-size: 0.78rem; color: #6b7280; }
   code { color: #93c5fd; }
 `;
+
+/** Submits the budget form without leaving the page. Hosted variant only. */
+const SETTINGS_JS = `
+function postSettings(payload,confirmMsg,el){
+  if(confirmMsg&&!window.confirm(confirmMsg))return false;
+  if(el)el.disabled=true;
+  fetch('/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})
+    .then(function(r){return r.json().then(function(b){return {ok:r.ok,body:b}})})
+    .then(function(res){
+      if(!res.ok){window.alert('Could not save: '+(res.body&&res.body.error||'unknown error'));if(el)el.disabled=false;return;}
+      if(res.body&&res.body.enforcementChanged)window.alert(res.body.frozen?'Saved. Spend is over the new budget - every user has been frozen.':'Saved. Spend is now under budget - the freeze has been lifted and balances restored.');
+      location.reload();
+    })
+    .catch(function(e){window.alert('Could not save: '+e.message);if(el)el.disabled=false;});
+  return false;
+}
+function saveSettings(ev,confirmMsg){
+  ev.preventDefault();
+  var f=ev.target;
+  return postSettings({budgetUsd:f.budgetUsd.value,period:f.period.value},confirmMsg,f.querySelector('button[type=submit]'));
+}
+function resetSettings(ev){
+  return postSettings({budgetUsd:null,period:null},'Drop both overrides and use the environment defaults again?',ev.target);
+}`;
 
 /** Posts iframe size and forwards tool actions. Used only by the MCP variant. */
 const MCP_JS = `
@@ -174,6 +207,76 @@ function usersSection(s: Snapshot, enforcement: EnforceState, variant: Variant):
   </section>`;
 }
 
+
+/** Human label for a period, so the select does not read like an enum dump. */
+const PERIOD_LABELS: Record<string, string> = {
+  'calendar-month': 'Calendar month (resets on the 1st)',
+  'calendar-week': 'Calendar week (resets Monday)',
+  'rolling-30d': 'Rolling 30 days (slides, never resets)',
+  'rolling-7d': 'Rolling 7 days (slides, never resets)',
+};
+
+/**
+ * Budget and period editor. Both normally come from the environment, so each field shows
+ * whether it is currently overridden and what the env default would be - otherwise a
+ * surprising budget is impossible to explain without reading the deployment.
+ */
+function settingsSection(
+  effective: EffectiveConfig,
+  envDefaults: Pick<Config, 'budgetUsd' | 'period'>,
+  mode: EnforceMode,
+  variant: Variant,
+): string {
+  const badge = (on: boolean, envValue: string) =>
+    on
+      ? `<span class="badge on" title="Overridden here; environment default is ${esc(envValue)}">override</span>`
+      : '<span class="badge">from env</span>';
+
+  const options = PERIODS.map(
+    (p) =>
+      `<option value="${p}"${p === effective.period ? ' selected' : ''}>${esc(PERIOD_LABELS[p] ?? p)}</option>`,
+  ).join('');
+
+  const changedNote =
+    effective.overrideUpdatedAt != null
+      ? `<div class="sub muted" style="margin-top:.5rem">last changed ${esc(stamp(effective.overrideUpdatedAt))}${
+          effective.overrideUpdatedBy != null ? ` by ${esc(effective.overrideUpdatedBy)}` : ''
+        }</div>`
+      : '';
+
+  const freezeWarning =
+    mode === 'on'
+      ? 'Lowering the budget below current spend will freeze every user on the next poll. Continue?'
+      : 'Apply the new budget and period?';
+
+  if (variant === 'mcp') {
+    return `<section>
+    <h2>Budget <span class="hint">- change via the set_org_budget tool</span></h2>
+    <table><tbody>
+      <tr><td>Budget</td><td>${usd(effective.budgetUsd)} ${badge(effective.overridden.budgetUsd, usd(envDefaults.budgetUsd))}</td></tr>
+      <tr><td>Period</td><td>${esc(PERIOD_LABELS[effective.period] ?? effective.period)} ${badge(effective.overridden.period, envDefaults.period)}</td></tr>
+    </tbody></table>${changedNote}
+  </section>`;
+  }
+
+  return `<section>
+    <h2>Budget</h2>
+    <form class="settings" onsubmit="return saveSettings(event, ${jsArg(freezeWarning)})">
+      <div>
+        <label for="budgetUsd">Budget (USD) ${badge(effective.overridden.budgetUsd, usd(envDefaults.budgetUsd))}</label>
+        <input id="budgetUsd" name="budgetUsd" type="number" min="0" step="0.01" value="${effective.budgetUsd}" />
+      </div>
+      <div>
+        <label for="period">Period ${badge(effective.overridden.period, envDefaults.period)}</label>
+        <select id="period" name="period">${options}</select>
+      </div>
+      <button class="btn" type="submit">Save</button>
+      <button class="btn ghost" type="button" onclick="return resetSettings(event)"
+        title="Drop the overrides and use SPEND_MONITOR_BUDGET_USD / SPEND_MONITOR_PERIOD again">Use env defaults</button>
+    </form>${changedNote}
+  </section>`;
+}
+
 /** Renders the shared dashboard body (banner, enforcement, tables, footer). */
 function dashboardBody(
   s: Snapshot,
@@ -181,6 +284,8 @@ function dashboardBody(
   enforcement: EnforceState,
   variant: Variant,
   pollSeconds: number,
+  effective: EffectiveConfig,
+  envDefaults: Pick<Config, 'budgetUsd' | 'period'>,
 ): string {
   const c = COLORS[s.level];
   const pct = Math.round(s.usedRatio * 100);
@@ -225,6 +330,8 @@ function dashboardBody(
     <table><thead><tr><th>Model</th><th>Provider</th><th>Spend</th></tr></thead><tbody>${modelRows || '<tr><td colspan="3">no usage yet</td></tr>'}</tbody></table>
   </section>
 
+  ${settingsSection(effective, envDefaults, mode, variant)}
+
   ${usersSection(s, enforcement, variant)}
 
   <footer>
@@ -241,6 +348,8 @@ export function renderPage(
   mode: EnforceMode,
   enforcement: EnforceState,
   pollSeconds: number,
+  effective: EffectiveConfig,
+  envDefaults: Pick<Config, 'budgetUsd' | 'period'>,
 ): string {
   return `<!doctype html>
 <html lang="en">
@@ -252,13 +361,20 @@ export function renderPage(
 <style>${STYLES}</style>
 </head>
 <body>
-<div class="wrap">${dashboardBody(s, mode, enforcement, 'hosted', pollSeconds)}</div>
+<div class="wrap">${dashboardBody(s, mode, enforcement, 'hosted', pollSeconds, effective, envDefaults)}</div>
+<script>${SETTINGS_JS}</script>
 </body>
 </html>`;
 }
 
 /** Embedded MCP-UI variant: no meta-refresh; buttons post tool actions. */
-export function renderMcpUi(s: Snapshot, mode: EnforceMode, enforcement: EnforceState): string {
+export function renderMcpUi(
+  s: Snapshot,
+  mode: EnforceMode,
+  enforcement: EnforceState,
+  effective: EffectiveConfig,
+  envDefaults: Pick<Config, 'budgetUsd' | 'period'>,
+): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -268,7 +384,7 @@ export function renderMcpUi(s: Snapshot, mode: EnforceMode, enforcement: Enforce
 <style>${STYLES}</style>
 </head>
 <body>
-<div class="wrap">${dashboardBody(s, mode, enforcement, 'mcp', 0)}</div>
+<div class="wrap">${dashboardBody(s, mode, enforcement, 'mcp', 0, effective, envDefaults)}</div>
 <script>${MCP_JS}</script>
 </body>
 </html>`;

--- a/packages/spend-monitor/src/server.ts
+++ b/packages/spend-monitor/src/server.ts
@@ -30,6 +30,10 @@ import { logNotifier } from './notify.ts';
 import { getEnforceState, enforceCap, restoreBalances, clearStaleOverride } from './enforce.ts';
 import type { EnforceState } from './enforce.ts';
 import { resetUserLimit } from './users.ts';
+import { effectiveConfig, updateSettings } from './settings.ts';
+import type { EffectiveConfig, SettingsPatch } from './settings.ts';
+import { PERIODS } from './config.ts';
+import type { Period } from './config.ts';
 import { renderPage } from './page.ts';
 import { setupMcpEndpoints, extractUserContext } from './utils/http-server.ts';
 import { createSession } from './mcp.ts';
@@ -45,10 +49,19 @@ async function main(): Promise<void> {
   let latest: Snapshot | null = null;
   let prevLevel: Level = 'ok';
   let enforceState: EnforceState = { active: false, since: null, reason: null, overridePeriodStart: null };
+  /** Budget and period can be overridden at runtime, so they are re-read every poll. */
+  let effective: EffectiveConfig = await effectiveConfig(db, cfg);
 
-  async function refresh(): Promise<void> {
+  /**
+   * Re-reads the settings, re-aggregates, and applies enforcement. Returns true when the
+   * freeze state flipped in this pass, so a caller that just changed the budget can report
+   * what actually happened rather than predicting it.
+   */
+  async function refresh(): Promise<boolean> {
     try {
-      const snap = await aggregate(db, cfg, new Date());
+      effective = await effectiveConfig(db, cfg);
+      let snap = await aggregate(db, effective, new Date());
+      const wasActive = enforceState.active;
 
       if (cfg.enforce !== 'off') {
         const dryRun = cfg.enforce === 'dry-run';
@@ -67,6 +80,12 @@ async function main(): Promise<void> {
           await restoreBalances(db, dryRun, null);
         }
         enforceState = await getEnforceState(db);
+        /* Enforcement writes balances after the aggregation read them, so the snapshot would
+         * still show pre-freeze credits for a whole poll. Re-aggregate once when the state
+         * actually flipped. */
+        if (enforceState.active !== wasActive) {
+          snap = await aggregate(db, effective, new Date());
+        }
       }
 
       if (snap.level !== prevLevel) {
@@ -74,11 +93,13 @@ async function main(): Promise<void> {
         prevLevel = snap.level;
       }
       latest = snap;
+      return enforceState.active !== wasActive;
     } catch (error) {
       logger.error(
         { error: error instanceof Error ? error.message : String(error) },
         'Spend refresh failed',
       );
+      return false;
     }
   }
 
@@ -93,7 +114,20 @@ async function main(): Promise<void> {
       res.status(503).json({ error: 'no data yet' });
       return;
     }
-    res.json({ ...latest, enforce: cfg.enforce, enforcement: enforceState });
+    res.json({
+      ...latest,
+      enforce: cfg.enforce,
+      enforcement: enforceState,
+      settings: {
+        budgetUsd: effective.budgetUsd,
+        period: effective.period,
+        overridden: effective.overridden,
+        updatedAt: effective.overrideUpdatedAt,
+        updatedBy: effective.overrideUpdatedBy,
+        envDefaults: { budgetUsd: cfg.budgetUsd, period: cfg.period },
+        periods: PERIODS,
+      },
+    });
   });
 
   app.get('/', async (_req: Request, res: Response) => {
@@ -102,7 +136,51 @@ async function main(): Promise<void> {
       res.status(503).send('no data yet');
       return;
     }
-    res.type('html').send(renderPage(latest, cfg.enforce, enforceState, cfg.pollSeconds));
+    res.type('html').send(
+      renderPage(latest, cfg.enforce, enforceState, cfg.pollSeconds, effective, cfg),
+    );
+  });
+
+  // Change the org-wide budget or accounting period without a redeploy. Stored in the
+  // monitor's own state collection; an empty value clears the override and falls back to
+  // SPEND_MONITOR_BUDGET_USD / SPEND_MONITOR_PERIOD.
+  app.use('/settings', express.urlencoded({ extended: false }), express.json({ limit: '16kb' }));
+  app.post('/settings', async (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const patch: SettingsPatch = {};
+
+    if ('budgetUsd' in body) {
+      const raw = body.budgetUsd;
+      const text = typeof raw === 'string' ? raw.trim() : raw;
+      patch.budgetUsd = text === '' || text == null ? null : Number(text);
+    }
+    if ('period' in body) {
+      const raw = typeof body.period === 'string' ? body.period.trim() : '';
+      patch.period = raw === '' ? null : (raw as Period);
+    }
+    if (Object.keys(patch).length === 0) {
+      res.status(400).json({ error: 'nothing to change: pass budgetUsd and/or period' });
+      return;
+    }
+
+    try {
+      const applied = await updateSettings(db, cfg, patch, 'dashboard');
+      const enforcementChanged = await refresh();
+      res.json({
+        budgetUsd: applied.budgetUsd,
+        period: applied.period,
+        overridden: applied.overridden,
+        level: latest?.level,
+        /** What the change actually did: a lower budget can freeze everyone immediately,
+         *  a higher one can lift a freeze. */
+        frozen: enforceState.active,
+        enforcementChanged,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error({ error: message, patch }, 'Settings update failed');
+      res.status(400).json({ error: message });
+    }
   });
 
   // Reset one user's limit (the dashboard's per-row "Reset" button). Writes to the user's

--- a/packages/spend-monitor/src/settings.ts
+++ b/packages/spend-monitor/src/settings.ts
@@ -1,0 +1,121 @@
+import type { Db } from 'mongodb';
+import type { Config, Period } from './config.ts';
+import { PERIODS } from './config.ts';
+import { logger } from './utils/logger.ts';
+
+/** Same collection the enforcement state lives in; a separate doc, different lifecycle. */
+const STATE = 'spendmonitor_state';
+const SETTINGS_ID = 'settings';
+
+/**
+ * Admin overrides for the values that would otherwise need a redeploy to change.
+ * Absent fields mean "use the env default", so clearing an override is a real operation
+ * rather than writing the current default back in.
+ */
+export interface Overrides {
+  budgetUsd?: number;
+  period?: Period;
+  /** Who changed it last and when - the page shows this so a surprising budget is traceable. */
+  updatedAt?: string;
+  updatedBy?: string;
+}
+
+interface SettingsDoc extends Overrides {
+  _id: string;
+}
+
+/** The config actually in force: env defaults with any stored override applied on top. */
+export interface EffectiveConfig extends Config {
+  /** Which fields come from the database rather than the environment. */
+  overridden: { budgetUsd: boolean; period: boolean };
+  overrideUpdatedAt: string | null;
+  overrideUpdatedBy: string | null;
+}
+
+export async function getOverrides(db: Db): Promise<Overrides> {
+  const doc = await db.collection<SettingsDoc>(STATE).findOne({ _id: SETTINGS_ID });
+  if (!doc) {
+    return {};
+  }
+  const budgetUsd = typeof doc.budgetUsd === 'number' && doc.budgetUsd > 0 ? doc.budgetUsd : undefined;
+  const period = doc.period != null && PERIODS.includes(doc.period) ? doc.period : undefined;
+  return { budgetUsd, period, updatedAt: doc.updatedAt, updatedBy: doc.updatedBy };
+}
+
+/** Merges stored overrides onto the env-derived config. */
+export function applyOverrides(cfg: Config, overrides: Overrides): EffectiveConfig {
+  return {
+    ...cfg,
+    budgetUsd: overrides.budgetUsd ?? cfg.budgetUsd,
+    period: overrides.period ?? cfg.period,
+    overridden: {
+      budgetUsd: overrides.budgetUsd != null,
+      period: overrides.period != null,
+    },
+    overrideUpdatedAt: overrides.updatedAt ?? null,
+    overrideUpdatedBy: overrides.updatedBy ?? null,
+  };
+}
+
+export async function effectiveConfig(db: Db, cfg: Config): Promise<EffectiveConfig> {
+  return applyOverrides(cfg, await getOverrides(db));
+}
+
+export interface SettingsPatch {
+  /** A number sets the override; null clears it and falls back to the env default. */
+  budgetUsd?: number | null;
+  period?: Period | null;
+}
+
+/**
+ * Writes or clears the overrides. Returns the config in force afterwards, so the caller can
+ * report what actually changed instead of echoing the request back.
+ */
+export async function updateSettings(
+  db: Db,
+  cfg: Config,
+  patch: SettingsPatch,
+  updatedBy: string,
+): Promise<EffectiveConfig> {
+  const set: Partial<SettingsDoc> = { updatedAt: new Date().toISOString(), updatedBy };
+  const unset: Record<string, ''> = {};
+
+  if (patch.budgetUsd !== undefined) {
+    if (patch.budgetUsd === null) {
+      unset.budgetUsd = '';
+    } else {
+      if (!Number.isFinite(patch.budgetUsd) || patch.budgetUsd <= 0) {
+        throw new Error(`budget must be a positive number, got ${patch.budgetUsd}`);
+      }
+      set.budgetUsd = patch.budgetUsd;
+    }
+  }
+  if (patch.period !== undefined) {
+    if (patch.period === null) {
+      unset.period = '';
+    } else {
+      if (!PERIODS.includes(patch.period)) {
+        throw new Error(`unknown period ${patch.period}; expected one of ${PERIODS.join(', ')}`);
+      }
+      set.period = patch.period;
+    }
+  }
+
+  await db.collection<SettingsDoc>(STATE).updateOne(
+    { _id: SETTINGS_ID },
+    { $set: set, ...(Object.keys(unset).length > 0 ? { $unset: unset } : {}) },
+    { upsert: true },
+  );
+
+  const applied = await effectiveConfig(db, cfg);
+  logger.warn(
+    {
+      budgetUsd: applied.budgetUsd,
+      period: applied.period,
+      overridden: applied.overridden,
+      updatedBy,
+    },
+    'Org spend settings changed',
+  );
+  return applied;
+}


### PR DESCRIPTION
Two unrelated things that both came out of the same session; happy to split if you prefer.

## 1. GitHub MCP was unusable on prod

Every tool call failed with `OAuth authentication required`. **The PAT is fine** — verified from inside the prod container:

- `GET api.github.com/user` → `200`, scopes include `repo`, `copilot`, `admin:org`
- `POST https://api.githubcopilot.com/mcp/` → `200`, full `initialize` response, no `WWW-Authenticate`

The prod logs show what actually happens:

```
[MCP][github] OAuth Required: true
[MCP][github][<user>] No stored tokens, proactively triggering OAuth flow
[MCP][github][<user>] Failed to initiate OAuth flow: Incompatible auth server:
                      does not support dynamic client registration
[MCP][github][pull_request_read] Error calling MCP tool: OAuth authentication failed
```

LibreChat probes the URL **without** the Authorization header, GitHub answers `401` with a challenge, and `isOAuthError` treats any 401/403 as "this server speaks OAuth" (`connection.ts:2485`). Every tool call then runs a per-user OAuth flow instead of using our machine-user PAT — and GitHub's auth server has no dynamic client registration, so the flow cannot even start.

`requiresOAuth: false` short-circuits the probe (`UserConnectionManager.ts:645`). This is the same fix already applied to the `search` server for the same reason; `github` simply never got it.

## 2. The org budget is editable at runtime

Changing `SPEND_MONITOR_BUDGET_USD` meant a redeploy. New `settings.ts` stores overrides in the monitor's own `spendmonitor_state` collection and merges them over the env config on every poll, so the env vars become defaults:

- **Budget** form on the dashboard, `POST /settings`, and a `set_org_budget` MCP tool
- each field shows whether it is overridden, with the env default in the tooltip; **Use env defaults** drops them
- two new periods: **`calendar-week`** (resets Monday, UTC ISO weeks) and **`rolling-7d`**

Two problems this surfaced, both fixed rather than documented around:

- `refresh()` applied enforcement *after* aggregating, so a freeze it had just triggered left the snapshot showing pre-freeze balances for a whole poll. It now re-aggregates once when the freeze state actually flips.
- the response predicted `enforcementWillFreeze`, which could never be true because the freeze had already happened in the same call. It now reports what occurred (`frozen`, `enforcementChanged`) and the dialog says which way it went.

### Verified against a throwaway MongoDB

| Case | Result |
|---|---|
| set / clear / persist across restart | env `100`+`calendar-month`, effective `175`+`calendar-week` after restart |
| validation | negative budget, unknown period, empty patch → `400` with a specific message |
| weekly window | `periodStart` Mon 27 Jul, resets Mon 3 Aug |
| `rolling-7d` | `periodResetAt: null` (slides, never resets) |
| budget below spend, `enforce=on` | `frozen: true, enforcementChanged: true`, balance `$20 → $0` in the same response |
| budget raised back | freeze lifted, balance restored to `$20` |

Config still validates strictly against `librechat-data-provider`'s `configSchema`; spend-monitor `tsc` clean.

## Deploy note

The GitHub fix needs the **librechat-init** image (it ships `librechat.yaml`) plus an API restart to reload the config. The budget feature needs the **spend-monitor** image. Both build from this merge.