### PR TITLE
feat: Kimi K3, Assistant recursion limit 500, working gh CLI in workspaces

### DIFF
--- a/docker-compose.mcp-linux.yml
+++ b/docker-compose.mcp-linux.yml
@@ -12,6 +12,10 @@ services:
       WORKER_IDLE_TIMEOUT: ${MCP_LINUX_WORKER_IDLE_TIMEOUT:-1800000}
       MCP_LINUX_WORKER_REQUEST_TIMEOUT_MS: ${MCP_LINUX_WORKER_REQUEST_TIMEOUT_MS:-120000}
       GIT_SSH_KEY: ${MCP_LINUX_GIT_SSH_KEY:-}
+      # Authenticates the `gh` CLI inside each workspace (user-manager writes ~/.config/gh/
+      # hosts.yml from it). Without this the image ships gh but no credentials, so every
+      # gh command fails. Same machine-user PAT the GitHub MCP server uses.
+      MCP_GITHUB_PAT: ${MCP_GITHUB_PAT:-}
       MCP_LINUX_GIT_USER_NAME: ${MCP_LINUX_GIT_USER_NAME:-}
       MCP_LINUX_GIT_USER_EMAIL: ${MCP_LINUX_GIT_USER_EMAIL:-}
       MCP_LINUX_UPLOAD_BASE_URL: ${MCP_LINUX_UPLOAD_BASE_URL:-}

--- a/packages/librechat-init/config/agents.yaml
+++ b/packages/librechat-init/config/agents.yaml
@@ -110,8 +110,13 @@ agents:
       - Convert this file to another format
       - Review a pull request or open an issue
       - Research a topic and summarize the findings
-    # Single agent, long sessions, no router chain.
-    recursion_limit: 150
+    # Graph steps per run (LangGraph recursionLimit), NOT a lifetime cap on replies: each
+    # LLM call and each tool round consumes one. Hitting it aborts that single run with a
+    # recursion error. There is no "unlimited" - LangGraph requires a finite number.
+    # 500 because this agent runs long single-agent sessions with many tool rounds
+    # (shell, file, GitHub) and 150 was being exhausted. No endpoint-level maxRecursionLimit
+    # is set, so this value applies as-is.
+    recursion_limit: 500
     handoffs:
       - agent: shared-agent-faktencheck
         description: "Transfer to Faktencheck Assistant for German fact-checks, verifying claims, or finding existing checks in Faktenforum"

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -127,6 +127,7 @@ endpoints:
           "deepseek/deepseek-v4-pro",         # DeepSeek V4 Pro (long context)
           "x-ai/grok-4.3",                    # xAI reasoning model (Vision)
           "moonshotai/kimi-k2.6",             # Cheap long-context reasoning (Vision)
+          "moonshotai/kimi-k3",               # Kimi K3 (1M Context, Vision) - premium tier
           "mistralai/mistral-large-2512"      # European premium option (French)
         ]
         # fetch all models from the API. Prod also uses fetch: true now; the selector stays
@@ -582,11 +583,26 @@ modelSpecs:
         maxContextTokens: 1050000
         maxOutputTokens: 128000
 
+    - name: "moonshotai-kimi-k3"
+      label: "Kimi K3"
+      description: "Moonshots Frontier-Modell (2.8T Parameter, MoE). 1M Context, 64K Output. Text, Code und Vision, stark bei langen Agent-Workflows. Achtung: mit $3/$15 pro 1M Token teurer als Claude Sonnet 5 - für Standardaufgaben ist Kimi K2.6 die günstigere Wahl. Open Weights (Moonshot)."
+      group: "Premium-Modelle"
+      order: 12
+      vision: true
+      preset:
+        endpoint: "OpenRouter"
+        endpointType: "custom"
+        model: "moonshotai/kimi-k3"
+        # Every OpenRouter provider serves 1M+ context; Together caps at 1,000,000, so use that.
+        # Output: providers that report a cap say 262144, but we stay at the K2.6 ceiling.
+        maxContextTokens: 1000000
+        maxOutputTokens: 65536
+
     - name: "mistral-large-2512"
       label: "Mistral Large 3 2512"
       description: "Mistrals aktuellstes Großmodell (675B MoE, 41B aktiv). 262K Context. Text + Vision. Apache 2.0. Gute Option für Europa-relevante Premium-Aufgaben."
       group: "Premium-Modelle"
-      order: 12
+      order: 13
       vision: true
       preset:
         endpoint: "OpenRouter"
@@ -623,7 +639,7 @@ modelSpecs:
 
     - name: "moonshotai-kimi-k2.6"
       label: "Kimi K2.6"
-      description: "Günstiges Long-Context-Reasoning für Coding und Agents. 262K Context. Vision. Open Weights (Moonshot)."
+      description: "Günstiges Long-Context-Reasoning für Coding und Agents. 262K Context, 64K Output. Vision. Rund 5x günstiger als Kimi K3 - erste Wahl, wenn 262K Context reichen. Open Weights (Moonshot)."
       group: "Premium-Modelle"
       order: 11
       vision: true

--- a/packages/mcp-linux/src/user-manager.ts
+++ b/packages/mcp-linux/src/user-manager.ts
@@ -250,7 +250,13 @@ export class UserManager {
    */
   private async setupGitHubCli(username: string): Promise<void> {
     const githubPat = process.env.MCP_GITHUB_PAT;
-    if (!githubPat) return;
+    if (!githubPat) {
+      logger.info(
+        { username },
+        'MCP_GITHUB_PAT not set; GitHub CLI stays unauthenticated (gh commands will fail)',
+      );
+      return;
+    }
 
     const ghConfigDir = `/home/${username}/.config/gh`;
     const ghHostsFile = join(ghConfigDir, 'hosts.yml');
@@ -258,13 +264,14 @@ export class UserManager {
     try {
       await fs.mkdir(ghConfigDir, { recursive: true });
 
-      // Write GitHub CLI hosts config with PAT authentication
-      const gitUserName = process.env.MCP_LINUX_GIT_USER_NAME || 'faktenforum-mcp-bot';
+      /* `user` is the GitHub login, which only the token knows - MCP_LINUX_GIT_USER_NAME is the
+       * git author display name and was the wrong source. Resolve it from the API and omit the
+       * field entirely when that fails, since gh can derive it from the token itself. */
+      const login = await this.resolveGitHubLogin(githubPat);
       const ghHostsConfig = `github.com:
     oauth_token: ${githubPat}
     git_protocol: ssh
-    user: ${gitUserName}
-`;
+${login ? `    user: ${login}\n` : ''}`;
       await fs.writeFile(ghHostsFile, ghHostsConfig, { mode: 0o600 });
 
       // Set ownership and permissions
@@ -272,9 +279,35 @@ export class UserManager {
       await execFile('chown', ['-R', `${username}:${username}`, ghConfigDir]);
       await fs.chmod(ghHostsFile, 0o600);
 
-      logger.info({ username }, 'GitHub CLI configured with PAT');
+      logger.info({ username, login }, 'GitHub CLI configured with PAT');
     } catch (error) {
       logger.warn({ username, error }, 'Failed to configure GitHub CLI');
+    }
+  }
+
+  /**
+   * Looks up the login belonging to the PAT. Returns null on any failure - an unresolved
+   * login is not worth failing the whole user setup over, and gh works without the field.
+   */
+  private async resolveGitHubLogin(pat: string): Promise<string | null> {
+    try {
+      const response = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${pat}`,
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'mcp-linux',
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        logger.warn({ status: response.status }, 'Could not resolve the GitHub login for the PAT');
+        return null;
+      }
+      const body = (await response.json()) as { login?: unknown };
+      return typeof body.login === 'string' && body.login.length > 0 ? body.login : null;
+    } catch (error) {
+      logger.warn({ error }, 'Could not resolve the GitHub login for the PAT');
+      return null;
     }
   }
 


### PR DESCRIPTION
Three items. The MCP icon rework lives in faktenforum/LibreChat#6; once that merges I will add the pointer bump here so everything ships in one release.

## 1. `gh` CLI never worked in a Linux workspace

The image installs the GitHub CLI and `setupGitHubCli()` writes `~/.config/gh/hosts.yml` from `MCP_GITHUB_PAT` — but `docker-compose.mcp-linux.yml` **never passed that variable in**, so the function returned on its first line and every `gh` command ran unauthenticated. Confirmed on prod:

```
MCP_GITHUB_PAT set: NO
no gh hosts.yml for any user
```

Fixed by passing the same machine-user PAT the GitHub MCP server uses. The no-PAT path now logs why gh will fail instead of silently doing nothing.

**Second bug in the same function:** `user` in hosts.yml is the GitHub *login*, but it was filled from `MCP_LINUX_GIT_USER_NAME` — the git author display name (`git config user.name`), a different thing, and empty in our deployment, so it fell back to a hardcoded `faktenforum-mcp-bot` that does not exist. Only the token knows the login, so it is now resolved from `GET /user`, and the field is omitted when that fails since gh derives it from the token anyway.

Verified: the rendered hosts.yml parses as YAML both with and without the login line, and the prod PAT resolves to `correctiv-team-digital-bot`.

> This grants no access the token lacks. A push to a repo the machine user is not a collaborator on still fails, correctly — see the note at the bottom.

## 2. Assistant recursion limit 150 → 500

`recursion_limit` is the LangGraph **step budget for a single run** — each LLM call and each tool round consumes one — and hitting it aborts that run with a recursion error. It is not a lifetime cap on replies, which is the natural but wrong reading of "150 responses"; the comment now says so.

**There is no "unlimited":** LangGraph requires a finite number. No endpoint-level `maxRecursionLimit` is configured, so the per-agent value applies as-is (`resolveRecursionLimit`), and the seeder writes `recursion_limit` on its **update** path too — so re-running `librechat-init` lifts the limit on the existing prod agent, not just a fresh one.

## 3. Kimi K3

**Yes on OpenRouter** — `moonshotai/kimi-k3`, 1M context, vision. **No on Scaleway** — still the same 18 models, no Kimi.

Added, not swapped, because K3 is not an upgrade in the same price band:

| Model | Context | Price / 1M | |
|---|---|---|---|
| `moonshotai/kimi-k2.6` | 262K | **$0.65 / $2.72** | the cheap long-context option |
| `moonshotai/kimi-k3` | 1M | **$3.00 / $15.00** | 4.6× / 5.5× more |
| `anthropic/claude-sonnet-5` | 1M | $2.00 / $10.00 | *cheaper than K3* |

Replacing K2.6 would have deleted the cheap long-context slot and quietly put a model there that costs **more than Claude Sonnet 5** — which matters with $30 per-user budgets. Both descriptions now name the trade-off, so the choice is visible in the model picker instead of only in the invoice.

## Verification

All **26** spec models and both endpoint fallback lists resolve against the live OpenRouter and Scaleway catalogs; no spec exceeds a reported context or output limit; `order` gapless and alphabetical; config validates strictly against `configSchema`; `agents.yaml` parses; `mcp-linux` tsc clean.

## Not in scope: repo access

The remaining push failure is an access decision, not a bug:

```
ERROR: Permission to gjsify/gjsify.git denied to correctiv-team-digital-bot.
```

`correctiv-team-digital-bot` is not a collaborator on `gjsify/gjsify` (checked: `sammydre`, `JumpLink`, `ewlsh`, `schnz`). Options are to add the bot with write access, or have the agent work fork-and-PR. Needs a decision rather than code.

## Deploy

**librechat-init** (both YAMLs) + API restart, and **mcp-linux** for the gh fix — plus `MCP_GITHUB_PAT` must be present in the mcp-linux service env in Portainer.