### PR TITLE
feat(agents): support contact on every agent, artifacts for the Assistant, better push-denied guidance

### DIFF
--- a/docker-compose.librechat.yml
+++ b/docker-compose.librechat.yml
@@ -11,6 +11,9 @@ services:
     environment:
       MONGO_URI: ${LIBRECHAT_MONGO_URI:-mongodb://${STACK_NAME:-prod}-mongodb:27017/LibreChat}
       LIBRECHAT_DEFAULT_ADMINS: ${LIBRECHAT_DEFAULT_ADMINS:-}
+      # Support contact stamped onto every seeded agent (per-agent override in agents.yaml).
+      LIBRECHAT_SUPPORT_CONTACT_NAME: ${LIBRECHAT_SUPPORT_CONTACT_NAME:-}
+      LIBRECHAT_SUPPORT_CONTACT_EMAIL: ${LIBRECHAT_SUPPORT_CONTACT_EMAIL:-}
       UID: ${UID:-1000}
       GID: ${GID:-1000}
       LIBRECHAT_CUSTOM_WELCOME: ${LIBRECHAT_CUSTOM_WELCOME:-}
@@ -48,6 +51,9 @@ services:
     environment:
       MONGO_URI: ${LIBRECHAT_MONGO_URI:-mongodb://${STACK_NAME:-prod}-mongodb:27017/LibreChat}
       LIBRECHAT_DEFAULT_ADMINS: ${LIBRECHAT_DEFAULT_ADMINS:-}
+      # Support contact stamped onto every seeded agent (per-agent override in agents.yaml).
+      LIBRECHAT_SUPPORT_CONTACT_NAME: ${LIBRECHAT_SUPPORT_CONTACT_NAME:-}
+      LIBRECHAT_SUPPORT_CONTACT_EMAIL: ${LIBRECHAT_SUPPORT_CONTACT_EMAIL:-}
       LIBRECHAT_API_URL: ${LIBRECHAT_API_URL:-http://api:3080}
       LIBRECHAT_JWT_SECRET: ${LIBRECHAT_JWT_SECRET}
       JWT_SECRET: ${LIBRECHAT_JWT_SECRET}

--- a/env.dev.example
+++ b/env.dev.example
@@ -47,6 +47,10 @@ GOOGLE_KEY=
 # LIBRECHAT_SEARXNG_URL=http://${STACK_NAME:-prod}-searxng:8080
 # FIRECRAWL_API_URL=http://${STACK_NAME:-prod}-firecrawl-api:3002
 
+# Support contact shown in every seeded agent's side panel (agents.yaml overrides per agent).
+LIBRECHAT_SUPPORT_CONTACT_NAME=Pascal Garber
+LIBRECHAT_SUPPORT_CONTACT_EMAIL=pascal.garber@correctiv.org
+
 # Spend Monitor (org cost dashboard + per-user limit resets; reuses LibreChat's MongoDB)
 # set your monthly org budget in USD
 SPEND_MONITOR_BUDGET_USD=100

--- a/env.local.example
+++ b/env.local.example
@@ -91,6 +91,9 @@ LIBRECHAT_ALLOW_REGISTRATION=true
 # LibreChat - Default Administrators (comma-separated email addresses)
 # Users with these email addresses will automatically be assigned the ADMIN role
 LIBRECHAT_DEFAULT_ADMINS=
+# Support contact shown in every seeded agent's side panel (agents.yaml can override per agent).
+LIBRECHAT_SUPPORT_CONTACT_NAME=Pascal Garber
+LIBRECHAT_SUPPORT_CONTACT_EMAIL=pascal.garber@correctiv.org
 # Set to false in production to disable self-registration
 # Users can then be created manually via: docker exec -it LibreChat npm run create-user
 LIBRECHAT_ALLOW_UNVERIFIED_EMAIL_LOGIN=false

--- a/env.prod.example
+++ b/env.prod.example
@@ -40,6 +40,10 @@ GOOGLE_KEY=
 # LIBRECHAT_SEARXNG_URL=http://${STACK_NAME:-prod}-searxng:8080
 # FIRECRAWL_API_URL=http://${STACK_NAME:-prod}-firecrawl-api:3002
 
+# Support contact shown in every seeded agent's side panel (agents.yaml overrides per agent).
+LIBRECHAT_SUPPORT_CONTACT_NAME=Pascal Garber
+LIBRECHAT_SUPPORT_CONTACT_EMAIL=pascal.garber@correctiv.org
+
 # Spend Monitor (org cost dashboard + per-user limit resets; reuses LibreChat's MongoDB)
 # set your monthly org budget in USD
 SPEND_MONITOR_BUDGET_USD=100

--- a/packages/librechat-init/config/agent-instructions/partial_instructions/code-git-ssh.md
+++ b/packages/librechat-init/config/agent-instructions/partial_instructions/code-git-ssh.md
@@ -1,1 +1,10 @@
 Git (GitHub): Use SSH only: remote URLs must be git@github.com:org/repo.git. Do not set origin to HTTPS with token or password. If remote is HTTPS, set to SSH: git remote set-url origin git@github.com:org/repo.git.
+
+Push denied: the workspace pushes as a shared machine account, not as the user, so a
+`Permission to <org>/<repo>.git denied to <account>` error means that account is not a
+collaborator - no credential change fixes it. Get the account name with
+`gh api user --jq .login` (never guess it), then tell the user which exact account to add
+with write access, and where: Settings > Collaborators on that repository. Offer working
+fork-and-PR as the alternative when they would rather not grant write access. Report the
+account name in both cases so they can act without a round trip.
+

--- a/packages/librechat-init/config/agents.yaml
+++ b/packages/librechat-init/config/agents.yaml
@@ -110,6 +110,9 @@ agents:
       - Convert this file to another format
       - Review a pull request or open an issue
       - Research a topic and summarize the findings
+    # Renders code/HTML/mermaid output as an interactive artifact panel instead of a wall of
+    # text. 'default' is the standard renderer ('shadcnui' and 'custom' also exist).
+    artifacts: default
     # Graph steps per run (LangGraph recursionLimit), NOT a lifetime cap on replies: each
     # LLM call and each tool round consumes one. Hitting it aborts that single run with a
     # recursion error. There is no "unlimited" - LangGraph requires a finite number.

--- a/packages/librechat-init/src/init-agents.ts
+++ b/packages/librechat-init/src/init-agents.ts
@@ -58,6 +58,10 @@ interface AgentConfig {
   category?: string;
   conversation_starters?: string[];
   recursion_limit?: number;
+  /** Artifact rendering mode: 'default' | 'shadcnui' | 'custom'. Empty/omitted disables artifacts. */
+  artifacts?: string;
+  /** Shown in the agent's side panel so users know who to contact about it. */
+  support_contact?: { name?: string; email?: string };
   /** @deprecated Use ACL permissions instead - only set for backward compatibility */
   isCollaborative?: boolean;
   permissions?: {
@@ -188,9 +192,23 @@ function buildAgentCreateData(agentConfig: AgentConfig): AgentCreateParams {
     tools: buildToolsArray(agentConfig),
     conversation_starters: agentConfig.conversation_starters,
     recursion_limit: agentConfig.recursion_limit,
-    support_contact: { name: '', email: '' },
+    support_contact: resolveSupportContact(agentConfig),
     edges: [],
-    artifacts: '',
+    artifacts: agentConfig.artifacts ?? '',
+  };
+}
+
+
+/**
+ * Support contact shown in an agent's side panel. Comes from the environment so one setting
+ * covers every agent, with a per-agent YAML override for the rare case that differs. Empty
+ * strings are what LibreChat stores for "unset", so an unconfigured deployment behaves as
+ * before rather than writing placeholder text.
+ */
+function resolveSupportContact(agentConfig: AgentConfig): { name: string; email: string } {
+  return {
+    name: agentConfig.support_contact?.name ?? process.env.LIBRECHAT_SUPPORT_CONTACT_NAME ?? '',
+    email: agentConfig.support_contact?.email ?? process.env.LIBRECHAT_SUPPORT_CONTACT_EMAIL ?? '',
   };
 }
 
@@ -209,6 +227,8 @@ function buildAgentUpdateData(agentConfig: AgentConfig): AgentUpdateParams {
     tools: buildToolsArray(agentConfig),
     conversation_starters: agentConfig.conversation_starters,
     recursion_limit: agentConfig.recursion_limit,
+    artifacts: agentConfig.artifacts ?? '',
+    support_contact: resolveSupportContact(agentConfig),
     isCollaborative: agentConfig.isCollaborative,
     // Clear edges/agent_ids in pass 1; pass 2 sets resolved values (YAML is source of truth)
     edges: [],


### PR DESCRIPTION
## Why the contact field was always blank

Not a missing config value — the seeder made it impossible to set:

```js
support_contact: { name: '', email: '' },   // create: hardcoded empty
// update payload: field absent entirely
```

`artifacts` had the same shape: hardcoded `''` on create, missing from update. So no YAML value could ever have reached an agent, and nothing could change on an existing one.

Both are configurable now and present on **both** paths, so a change lands on existing agents at the next `librechat-init` run rather than only on freshly created ones.

## Changes

- **Support contact** from `LIBRECHAT_SUPPORT_CONTACT_NAME` / `_EMAIL` — one setting covers every agent, with a per-agent `support_contact` override in `agents.yaml` for the case that differs. Set to Pascal Garber / pascal.garber@correctiv.org in the env examples. Empty stays empty, so an unconfigured deployment behaves exactly as before instead of writing placeholder text.
- **Artifacts** on the Assistant (`artifacts: default`), so code, HTML and mermaid render in the artifact panel instead of as a wall of text.
- **Push-denied guidance.** A denied push is an access problem, not a credential one, and the agent had no way to say something useful. The git partial now tells it to read the machine account's login with `gh api user --jq .login` — never guess — and name that exact account plus where to add it (Settings › Collaborators), or offer fork-and-PR instead. This only became possible because the gh CLI is finally authenticated in a workspace (#86).

## Verification

`librechat-init` tsc clean; `agents.yaml` and `docker-compose.librechat.yml` parse; artifacts/recursion per agent read back as expected (`Assistant artifacts=default recursion=500`, others unchanged).

## Deploy

**librechat-init** image + rerun, and `LIBRECHAT_SUPPORT_CONTACT_NAME` / `_EMAIL` need setting in Portainer. The rerun updates the existing agents in place.