### PR TITLE
fix: Scaleway token quota, background jobs, paged reads

### DIFF
--- a/docs/LIBRECHAT_FEATURES.md
+++ b/docs/LIBRECHAT_FEATURES.md
@@ -188,9 +188,22 @@ Compose sets `LIBRECHAT_ENV` per stack (local: `local`, dev: `dev`, prod: `prod`
 
 ### Scaleway: tokens-per-minute quota caps the usable context
 
-Scaleway rate-limits **per organization**, not per request: `x-ratelimit-limit-tokens: 200000` per minute and `x-ratelimit-limit-requests: 300` per minute, identical for every model we use (measured 2026-07-29 on glm-5.2, qwen3-235b, mistral-small-3.2).
+Scaleway rate-limits on three axes - **tokens per minute (input + output), requests per minute, and concurrent requests** - and the limits apply to the **Organization**, shared by all its Projects ([rate limits](https://www.scaleway.com/en/docs/generative-apis/reference-content/rate-limits/)).
 
-A request whose prompt alone exceeds that budget can never succeed. It fails with
+The token budget is **per model**, not one pot for everything. Measured 2026-07-29: a ~120k-token request on `glm-5.2` drove its `x-ratelimit-remaining-tokens` to 0 while `mistral-small-3.2` stayed untouched at ~99995. So agents on different models do not compete for the same budget; all users on the *same* model do.
+
+Two numbers matter, and they are not the same:
+
+| | value |
+|---|---|
+| `x-ratelimit-limit-tokens` reported for every model | 200000 |
+| `x-ratelimit-remaining-tokens` when idle | ~100000 |
+
+We only ever see about half the stated limit available at once, so plan against ~100k per minute per model, not 200k.
+
+**We are on the lower of two tiers.** Scaleway's [quota table](https://www.scaleway.com/en/docs/organizations-and-projects/additional-content/organization-quotas/#generative-apis---serverless) grants 200k tokens/minute per model with a payment method alone, and much more once the *identity* is verified as well - `glm-5.2` and `qwen3-235b` go to 1 000k, `mistral-small-3.2` to 2 000k. Verifying the identity in the console is therefore a 5x increase for the Assistant with no code change, and the single most effective fix here. Beyond that: the Batches API has no rate limit at all (-50% price, not usable for interactive chat), Dedicated Deployments have none either, and support raises quotas on request.
+
+A request whose prompt alone exceeds the remaining budget cannot succeed. It fails with
 
 ```
 429 {"error":"INSUFFICIENT QUOTA","message":"You exceeded your current quota of tokens per minute."}
@@ -201,7 +214,7 @@ surfaced in the chat as `An error occurred while processing the request: 429 "IN
 Two things make this hit sooner than the raw numbers suggest:
 
 - an agent turn sends the whole context **once per tool round**, so a 60k-token conversation with four tool calls spends ~240k tokens in one turn;
-- the quota is shared by all users and all agents on the same key.
+- every user on that model draws from the same budget, so concurrent chats add up.
 
 Therefore agent `maxContextTokens` is capped **below** the per-minute quota rather than at the model window (`Assistant`/glm-5.2: 96000 of 262144; `Faktencheck`/qwen3: 96000 of 250000). LibreChat then truncates old messages instead of building a request that cannot be served. Tool output is capped as well - see `MCP_LINUX_MAX_OUTPUT_CHARS` in [MCP Linux](MCP_LINUX.md).
 

--- a/docs/LIBRECHAT_FEATURES.md
+++ b/docs/LIBRECHAT_FEATURES.md
@@ -186,6 +186,29 @@ Compose sets `LIBRECHAT_ENV` per stack (local: `local`, dev: `dev`, prod: `prod`
 - `titleConvo: true` - Auto-generates conversation titles
 - `summarize: true` - Enables summarization for long conversations
 
+### Scaleway: tokens-per-minute quota caps the usable context
+
+Scaleway rate-limits **per organization**, not per request: `x-ratelimit-limit-tokens: 200000` per minute and `x-ratelimit-limit-requests: 300` per minute, identical for every model we use (measured 2026-07-29 on glm-5.2, qwen3-235b, mistral-small-3.2).
+
+A request whose prompt alone exceeds that budget can never succeed. It fails with
+
+```
+429 {"error":"INSUFFICIENT QUOTA","message":"You exceeded your current quota of tokens per minute."}
+```
+
+surfaced in the chat as `An error occurred while processing the request: 429 "INSUFFICIENT QUOTA"`. Retrying does not help, and the agents package sets `maxRetries: 0` on the OpenAI-compatible path, so the run ends immediately.
+
+Two things make this hit sooner than the raw numbers suggest:
+
+- an agent turn sends the whole context **once per tool round**, so a 60k-token conversation with four tool calls spends ~240k tokens in one turn;
+- the quota is shared by all users and all agents on the same key.
+
+Therefore agent `maxContextTokens` is capped **below** the per-minute quota rather than at the model window (`Assistant`/glm-5.2: 96000 of 262144; `Faktencheck`/qwen3: 96000 of 250000). LibreChat then truncates old messages instead of building a request that cannot be served. Tool output is capped as well - see `MCP_LINUX_MAX_OUTPUT_CHARS` in [MCP Linux](MCP_LINUX.md).
+
+The real fix is a higher quota: Scaleway raises the standard limits once a payment method and identity validation are in place, and grants more on request. Batch workloads can use the Batches API, which has no rate limit and costs 50% less - not applicable to interactive chat.
+
+**Sources:** [Rate limits for Generative APIs](https://www.scaleway.com/en/docs/generative-apis/reference-content/rate-limits/), [Understanding common errors](https://www.scaleway.com/en/docs/generative-apis/api-cli/understanding-errors/).
+
 ### Scaleway: parallel tool calls
 
 **Config:** Scaleway endpoint uses `addParams: { parallel_tool_calls: false }`.

--- a/docs/MCP_LINUX.md
+++ b/docs/MCP_LINUX.md
@@ -143,6 +143,7 @@ If you run **both** stacks on one host they also share the external network `loa
 | `MCP_LINUX_STATUS_COLLAPSE_DIRS` | `uploads,venv,.venv` | Comma-separated dirs whose paths are collapsed to one summary line in status |
 | `MCP_LINUX_RESOURCE_LIST_DIRS` | `uploads,outputs` | Comma-separated dirs listed in MCP resources (allowlist); only these appear in list |
 | `MCP_LINUX_UPLOADS_MAX_AGE_DAYS` | `0` (disabled) | If > 0, server runs daily cleanup of `uploads/` files older than N days |
+| `MCP_LINUX_MAX_OUTPUT_CHARS` | `40000` | Cap on terminal output returned per call (head 2/3 + tail 1/3, middle dropped). Uncapped output is re-sent with every model call for the rest of the turn and burns the provider's tokens-per-minute quota; `read_terminal_output` with an explicit `length` still pages the full text |
 
 ## Inline UI (MCP-UI)
 

--- a/docs/MCP_LINUX.md
+++ b/docs/MCP_LINUX.md
@@ -26,6 +26,20 @@ LibreChat can use one app-level MCP connection (`startup: true`), so one MCP ses
 | `list_terminals` | List active sessions |
 | `kill_terminal` | Terminate a session |
 
+Terminal output is capped per call (`MCP_LINUX_MAX_OUTPUT_CHARS`, default 40000): head two thirds, tail one third, with the omitted character count. Uncapped output was re-sent with every model call for the rest of the turn, which is what exhausts a provider's tokens-per-minute quota. Page the middle with `read_terminal_output` using `offset`/`length`.
+
+### Background jobs
+| Tool | Description |
+|------|-------------|
+| `start_job` | Run a command detached; returns `job_id` immediately and survives the turn |
+| `job_status` | State, exit code, output size, finish time |
+| `read_job_output` | Combined stdout/stderr, capped by default, pageable |
+| `wait_for_job` | Block until the job ends, reporting progress so the call does not time out |
+| `list_jobs` | Jobs newest first, including ones from earlier turns |
+| `kill_job` | SIGTERM to the process group |
+
+See [Background Jobs](#background-jobs) for how it works and what push notifications cannot do.
+
 A workspace is a plain per-project directory under `~/workspaces/`. Git is available on demand (init, clone, commit, push) but not required; a workspace can just hold files. One workspace = one task context.
 
 ### Workspace
@@ -80,7 +94,7 @@ First-class file tools (opencode-style) run in the per-user worker, so file owne
 
 | Tool | Description |
 |------|-------------|
-| `read_workspace_file` | Read a file as structured MCP content (text, image, audio). Text inline with line numbers; images/audio as base64; large or binary files get a download link. Limits: text 1 MB, binary 10 MB. |
+| `read_workspace_file` | Read a file as structured MCP content (text, image, audio). Text inline with line numbers, first 1200 lines by default - page further with `offset`/`limit`, or ask for exact `line_ranges`; the header states which lines of how many were returned. Images/audio as base64; large or binary files get a download link. Limits: text 1 MB, binary 10 MB. |
 | `list_workspace_files` | List files in a workspace directory; more effective than `ls` for exploring structure. |
 | `write` | Create (with parent dirs) or overwrite a file. Prefer over echoing content through `execute_command`. |
 | `edit` | Replace an exact string in an existing file. `old_string` must match exactly and be unique unless `replace_all: true`. |
@@ -153,6 +167,25 @@ The server ships small self-contained HTML views as MCP-UI resources (`ui://` te
 - `create_upload_session` returns an **upload widget** (drag & drop, progress) plus a browser URL. The widget renders inline; the same widget is served standalone at `GET /upload/:token` for a shareable link.
 
 The upload widget's iframe has an opaque origin, so `POST /upload/:token` and `GET /upload/:token/{config,status}` send permissive CORS headers (the token in the URL is the capability; no cookies are used). Downloads happen via the shared text URL: the chat iframe sandbox has no `allow-downloads`, so links inside the card are also shown as selectable text.
+
+## Background Jobs
+
+`execute_command` must answer inside the MCP call timeout, so anything that takes minutes (installs, builds, test suites) needs a different shape. `start_job` spawns the command detached and returns a `job_id` immediately; the job survives both the tool call and the end of the conversation turn.
+
+| Tool | Purpose |
+|------|---------|
+| `start_job` | Start a command in the background, returns `job_id` + `pid` |
+| `job_status` | State (`running`, `finished`, `failed`, `unknown`), exit code, output size |
+| `read_job_output` | Combined stdout/stderr, capped by default, pageable with `offset`/`length` |
+| `wait_for_job` | Blocks until the job ends, emitting `notifications/progress` every 2s |
+| `list_jobs` | All jobs, newest first - finds jobs started in an earlier turn |
+| `kill_job` | SIGTERM to the process group; output stays readable |
+
+State is files, not memory, so a worker restart does not lose a running job: `~/.mcp_jobs/<id>.json` (metadata), `<id>.log` (output), `<id>.exit` (exit code). The command runs in a subshell so that a `exit N` inside it still lets the wrapper record the code.
+
+**Why `wait_for_job` can run for minutes:** the MCP client resets its tool-call timeout on every progress notification (LibreChat sets `resetTimeoutOnProgress: true`). Verified with the official SDK client: a 6-second job returned successfully through a **4-second** client timeout, with 3 progress callbacks. This requires SSE responses, so the transport runs with `enableJsonResponse: false` - a JSON response is one body with no room for notifications.
+
+**What is not possible:** nothing wakes the agent between turns. LibreChat registers exactly one server-initiated notification handler (`notifications/resources/list_changed`, which only refreshes the resource list), and its agent loop has no entry point for an unsolicited event - a finished run cannot be resumed. So "notify me when the build is done" works *within* a turn via `wait_for_job`, or by the agent checking `list_jobs` when the user writes again. A real push would need LibreChat to consume MCP notifications and re-invoke the agent (upstream does not handle even `tools/list_changed` yet, see danny-avila/LibreChat#7117).
 
 ## Traefik Routing
 

--- a/packages/librechat-init/config/agents.yaml
+++ b/packages/librechat-init/config/agents.yaml
@@ -11,7 +11,13 @@ agents:
     model_parameters:
       temperature: 0.4
       top_p: 0.9
-      maxContextTokens: 262144   # GLM 5.2 (Scaleway: 262144 context, 16384 output cap)
+      # The model window is 262144, but Scaleway's quota is 200000 tokens *per minute* for the
+      # whole organization, and one agent turn sends the context again per tool round. A request
+      # over that budget can never succeed - it fails with 429 "INSUFFICIENT QUOTA" no matter how
+      # often it is retried - so the cap stays well below it and LibreChat truncates instead.
+      # 64000 leaves room for three tool rounds in one minute (3 x 64000 < 200000); this agent has
+      # the most tools and therefore the longest chains. Raise it once the Scaleway quota is raised.
+      maxContextTokens: 64000    # GLM 5.2 (window 262144, output cap 16384)
     tools:
       - web_search
       - file_search
@@ -208,7 +214,7 @@ agents:
     model_parameters:
       temperature: 0.7
       top_p: 0.8
-      maxContextTokens: 250000   # Qwen3 235B; Scaleway has no endpointTokenConfig
+      maxContextTokens: 96000    # Qwen3 235B (window 250000); capped for the same quota reason
     tools: []
     mcpServers:
       - mapbox

--- a/packages/mcp-linux/src/schemas/file.schema.ts
+++ b/packages/mcp-linux/src/schemas/file.schema.ts
@@ -14,6 +14,18 @@ export const ReadWorkspaceFileSchema = z.object({
     .array(z.tuple([z.number().int().min(1), z.number().int().min(1)]))
     .optional()
     .describe('Optional line ranges to read, e.g. [[1,50],[100,150]]. 1-based inclusive.'),
+  offset: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('First line to read (1-based). Use with limit to page through a long file.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('Maximum number of lines to return (default 1200). Read further with offset.'),
 });
 
 export const ListWorkspaceFilesSchema = z.object({

--- a/packages/mcp-linux/src/schemas/job.schema.ts
+++ b/packages/mcp-linux/src/schemas/job.schema.ts
@@ -1,0 +1,47 @@
+/**
+ * Schemas for background job tools.
+ */
+
+import { z } from 'zod';
+
+export const StartJobSchema = z.object({
+  command: z
+    .string()
+    .min(1)
+    .describe('Shell command to run in the background, e.g. "npm install" or "pytest -q"'),
+  workspace: z.string().default('default').describe('Workspace name (default: "default")'),
+});
+
+export const ListJobsSchema = z.object({
+  workspace: z.string().optional().describe('Only list jobs started in this workspace'),
+});
+
+export const JobStatusSchema = z.object({
+  job_id: z.string().min(1).describe('Job id returned by start_job'),
+});
+
+export const ReadJobOutputSchema = z.object({
+  job_id: z.string().min(1).describe('Job id returned by start_job'),
+  offset: z.number().int().min(0).optional().describe('Character offset to start reading from'),
+  length: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('Characters to read. Without it the output is capped and the middle is dropped.'),
+});
+
+export const WaitForJobSchema = z.object({
+  job_id: z.string().min(1).describe('Job id returned by start_job'),
+  timeout_seconds: z
+    .number()
+    .int()
+    .min(1)
+    .max(1800)
+    .default(300)
+    .describe('How long to wait before giving up on this call (default 300, max 1800)'),
+});
+
+export const KillJobSchema = z.object({
+  job_id: z.string().min(1).describe('Job id returned by start_job'),
+});

--- a/packages/mcp-linux/src/server.ts
+++ b/packages/mcp-linux/src/server.ts
@@ -31,6 +31,7 @@ import { registerUploadTools } from './tools/upload.ts';
 import { registerDownloadTools } from './tools/download.ts';
 import { registerFileTools } from './tools/file.ts';
 import { registerFilesystemTools } from './tools/filesystem.ts';
+import { registerJobTools } from './tools/job.ts';
 import { registerTodoTools } from './tools/todo.ts';
 import { registerPrompts } from './prompts/index.ts';
 import { registerWorkspaceResources } from './resources/workspace-resources.ts';
@@ -109,7 +110,13 @@ File Download:
 - create_download_link for a temporary download URL for any workspace file; share the URL with the user. Links are single-use, expire after 60 minutes by default. Cleanup: list_download_links, close_download_link to limit exposure.
 
 Reading Files:
-- read_workspace_file returns content with line numbers for diffing. Use optional line_ranges for specific sections. Text files are returned inline; images and audio as base64; large or binary files get a download link instead.
+- read_workspace_file returns content with line numbers for diffing. Use optional line_ranges for specific sections, or offset/limit to page through a long file - it returns the first 1200 lines by default and tells you the total, so read the part you need rather than the whole file. Text files are returned inline; images and audio as base64; large or binary files get a download link instead.
+
+Long-running commands:
+- execute_command has to answer within the call timeout, so use start_job for anything slow: installs, builds, test suites, downloads, long scripts. It returns a job_id immediately and the job keeps running after the turn ends.
+- Then either wait_for_job(job_id) to be handed the exit code and output as soon as it finishes (the call reports progress while waiting, so several minutes are fine), or carry on with other work and check job_status / read_job_output later. list_jobs finds jobs from earlier turns. kill_job stops one.
+- You are not notified on your own when a job finishes - nothing wakes you between turns. So either wait for it in the same turn, or tell the user you will report back and check with list_jobs at the start of your next reply.
+- Terminal and job output is capped per call (head and tail, middle dropped, with the omitted count). When you need the middle, page it with read_terminal_output / read_job_output using offset and length instead of re-running the command.
 
 Status card: Users can view and manage their account (workspaces, upload/download sessions, terminals) inline. Call get_status and place the returned UI resource marker (\\ui{id}) in your reply to render the interactive card. Its buttons (delete workspace, close upload session, revoke download link, kill terminal, refresh) arrive back as new messages asking you to run the matching tool; run it and report the result. There is no external status page. See the account_status prompt for details.`,
     },
@@ -123,6 +130,7 @@ Status card: Users can view and manage their account (workspaces, upload/downloa
   registerDownloadTools(server, userManager, downloadManager);
   registerFileTools(server, userManager, downloadManager);
   registerFilesystemTools(server, userManager, workerManager);
+  registerJobTools(server, userManager, workerManager);
   registerTodoTools(server);
 
   // Register resources
@@ -141,7 +149,10 @@ function createSession(): { server: McpServer; transport: StreamableHTTPServerTr
   const server = createMcpServer();
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
-    enableJsonResponse: true,
+    /* SSE responses, not plain JSON: a JSON response is a single body with no room for
+     * notifications/progress, so wait_for_job could never report progress and the client would cut
+     * the call off at its tool timeout. Every MCP client accepts text/event-stream by spec. */
+    enableJsonResponse: false,
     onsessioninitialized: (sessionId: string) => {
       logger.info({ sessionId, totalSessions: transports.size + 1 }, 'Session initialized');
       transports.set(sessionId, transport);

--- a/packages/mcp-linux/src/tools/file.ts
+++ b/packages/mcp-linux/src/tools/file.ts
@@ -70,6 +70,38 @@ function formatTextPage(content: string, offset: number, limit: number): string 
   );
 }
 
+/**
+ * Whether a file with an unrecognised extension is really text.
+ *
+ * The extension list can never be complete - `env.prod.example`, `Dockerfile.tpl`, `.env.secret`
+ * and friends all read as unknown, and handing back a download link for them makes the agent fall
+ * back to `cat` in the terminal: another round trip, and the output arrives without line numbers.
+ * A NUL byte is the same signal `file` and git use to call something binary.
+ */
+export async function looksLikeText(absolutePath: string): Promise<boolean> {
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(absolutePath, 'r');
+    const { buffer, bytesRead } = await handle.read(Buffer.alloc(8192), 0, 8192, 0);
+    const sample = buffer.subarray(0, bytesRead);
+    if (sample.includes(0)) {
+      return false;
+    }
+    /* Control characters other than tab, newline and carriage return point at binary content. */
+    let suspicious = 0;
+    for (const byte of sample) {
+      if (byte < 0x09 || (byte > 0x0d && byte < 0x20)) {
+        suspicious++;
+      }
+    }
+    return bytesRead === 0 || suspicious / bytesRead < 0.05;
+  } catch {
+    return false;
+  } finally {
+    await handle?.close();
+  }
+}
+
 /** Maximum text file size to inline (1 MB) */
 const MAX_TEXT_SIZE = 1 * 1024 * 1024;
 /** Maximum binary file size to inline as base64 (10 MB) */
@@ -205,7 +237,18 @@ export function registerFileTools(
           };
         }
 
-        // ── Unknown / binary files ─────────────────────────────────
+        // ── Unknown extension: decide by content ───────────────────
+        if (fileSize <= MAX_TEXT_SIZE && (await looksLikeText(absolutePath))) {
+          const rawContent = await fs.readFile(absolutePath, 'utf-8');
+          const text = args.line_ranges?.length
+            ? formatTextWithLineNumbers(rawContent, args.line_ranges)
+            : formatTextPage(rawContent, args.offset ?? 1, args.limit ?? DEFAULT_LINE_LIMIT);
+          return {
+            content: [{ type: 'text' as const, text }],
+          };
+        }
+
+        // ── Binary files ───────────────────────────────────────────
         return await createDownloadFallback(
           email, mapping.username, args.workspace, args.file_path,
           fileSize, downloadManager,

--- a/packages/mcp-linux/src/tools/file.ts
+++ b/packages/mcp-linux/src/tools/file.ts
@@ -17,6 +17,15 @@ import { resolveSafePath, ensureFileExists, ensureDirExists } from '../utils/fs-
 
 const SKIP_DIR_NAMES = new Set(['.git', 'node_modules', '.venv', 'venv']);
 
+/**
+ * Lines returned when the caller asks for no particular range.
+ *
+ * A whole file used to be inlined up to 1 MB, which is roughly 250k tokens - more than a provider
+ * grants per minute, so one read could make the rest of the turn impossible. Paging is the same
+ * bargain other coding agents strike: enough to work with, and an explicit way to ask for more.
+ */
+const DEFAULT_LINE_LIMIT = 1200;
+
 /** Format text with line numbers (1-based) for diffing or discussion. Optionally restrict to line ranges (1-based inclusive). */
 function formatTextWithLineNumbers(
   content: string,
@@ -35,6 +44,30 @@ function formatTextWithLineNumbers(
     }
   }
   return out.join('\n');
+}
+
+/** Renders a page of a text file with line numbers, plus a note when more lines exist. */
+function formatTextPage(content: string, offset: number, limit: number): string {
+  const lines = content.split(/\r?\n/);
+  const from = Math.min(Math.max(1, offset), Math.max(1, lines.length));
+  const to = Math.min(lines.length, from + limit - 1);
+
+  const body: string[] = [];
+  for (let i = from; i <= to; i++) {
+    body.push(`${i} | ${lines[i - 1] ?? ''}`);
+  }
+
+  if (from === 1 && to === lines.length) {
+    return body.join('\n');
+  }
+
+  const rest =
+    to < lines.length
+      ? ` Read on with offset=${to + 1}.`
+      : '';
+  return (
+    `[lines ${from}-${to} of ${lines.length}.${rest}]\n` + body.join('\n')
+  );
 }
 
 /** Maximum text file size to inline (1 MB) */
@@ -130,7 +163,11 @@ export function registerFileTools(
           }
 
           const rawContent = await fs.readFile(absolutePath, 'utf-8');
-          const text = formatTextWithLineNumbers(rawContent, args.line_ranges);
+          /* Explicit line_ranges are a deliberate request and are honoured as given; everything
+           * else is paged so a long file cannot swallow the turn's token budget. */
+          const text = args.line_ranges?.length
+            ? formatTextWithLineNumbers(rawContent, args.line_ranges)
+            : formatTextPage(rawContent, args.offset ?? 1, args.limit ?? DEFAULT_LINE_LIMIT);
           return {
             content: [{ type: 'text' as const, text }],
           };

--- a/packages/mcp-linux/src/tools/job.ts
+++ b/packages/mcp-linux/src/tools/job.ts
@@ -1,0 +1,208 @@
+/**
+ * Background job tools.
+ *
+ * `execute_command` must answer inside the MCP call timeout, so anything that takes minutes - an
+ * install, a build, a long test run - either times out or forces the model to sit and wait. These
+ * tools split that in two: start the command detached, then either carry on and check later, or
+ * wait for it in a call that stays alive through progress notifications.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { randomUUID } from 'node:crypto';
+import type { UserManager } from '../user-manager.ts';
+import type { WorkerManager } from '../worker-manager.ts';
+import { resolveEmail, errorResult } from './helpers.ts';
+import { logger } from '../utils/logger.ts';
+import {
+  StartJobSchema,
+  ListJobsSchema,
+  JobStatusSchema,
+  ReadJobOutputSchema,
+  WaitForJobSchema,
+  KillJobSchema,
+} from '../schemas/job.schema.ts';
+
+/** How often wait_for_job checks - short enough to feel immediate, long enough not to spin. */
+const POLL_INTERVAL_MS = 2_000;
+
+interface JobStatusResult {
+  state: 'running' | 'finished' | 'failed' | 'unknown';
+  exit_code: number | null;
+  output_chars: number;
+}
+
+export function registerJobTools(
+  server: McpServer,
+  userManager: UserManager,
+  workerManager: WorkerManager,
+): void {
+  const call = async (email: string, method: string, params: Record<string, unknown>) => {
+    const response = await workerManager.sendRequest(email, { id: randomUUID(), method, params });
+    if (response.error) {
+      throw new Error(response.error);
+    }
+    return response.result;
+  };
+
+  const asText = (result: unknown) => ({
+    content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+  });
+
+  server.registerTool(
+    'start_job',
+    {
+      description:
+        'Start a shell command in the background and return immediately with a job_id. Use this for anything that takes longer than a few seconds - installs, builds, test suites, downloads, training runs - instead of blocking execute_command. ' +
+        'The job keeps running after this call returns, and after the conversation turn ends. ' +
+        'Then either continue working and call job_status / read_job_output later, or call wait_for_job to be handed the result as soon as it finishes. ' +
+        'Returns: job_id, pid, command, workspace, started_at, state.',
+      inputSchema: StartJobSchema.shape,
+    },
+    async (args, extra) => {
+      try {
+        const email = resolveEmail(extra);
+        return asText(
+          await call(email, 'start_job', { command: args.command, workspace: args.workspace }),
+        );
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'list_jobs',
+    {
+      description:
+        'List background jobs with their state (running, finished, failed, unknown), exit code, output size and timestamps. Newest first. Use it to pick up jobs started in an earlier turn.',
+      inputSchema: ListJobsSchema.shape,
+    },
+    async (args, extra) => {
+      try {
+        const email = resolveEmail(extra);
+        return asText(await call(email, 'list_jobs', { workspace: args.workspace }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'job_status',
+    {
+      description:
+        'Check one background job without reading its output: state, exit code, how much output it has produced so far, and when it finished.',
+      inputSchema: JobStatusSchema.shape,
+    },
+    async (args, extra) => {
+      try {
+        const email = resolveEmail(extra);
+        return asText(await call(email, 'job_status', { job_id: args.job_id }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'read_job_output',
+    {
+      description:
+        'Read the combined stdout and stderr of a background job. Works while it runs and after it ends. Without length the output is capped (head and tail, middle dropped); page through the full text with offset and length.',
+      inputSchema: ReadJobOutputSchema.shape,
+    },
+    async (args, extra) => {
+      try {
+        const email = resolveEmail(extra);
+        return asText(
+          await call(email, 'read_job_output', {
+            job_id: args.job_id,
+            offset: args.offset,
+            length: args.length,
+          }),
+        );
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'wait_for_job',
+    {
+      description:
+        'Wait for a background job and return as soon as it finishes, with its exit code and the tail of its output. ' +
+        'The call reports progress while waiting, which keeps it from timing out, so it can legitimately take minutes. ' +
+        'If the timeout is reached first the job is left running and can be waited on again.',
+      inputSchema: WaitForJobSchema.shape,
+    },
+    async (args, extra) => {
+      try {
+        const email = resolveEmail(extra);
+        const deadline = Date.now() + args.timeout_seconds * 1000;
+        /* Without a progress token the client asked for no updates, so waiting long would risk its
+         * timeout; the loop still runs, it just cannot announce itself. */
+        const progressToken = extra?._meta?.progressToken;
+        let polls = 0;
+
+        for (;;) {
+          const status = (await call(email, 'job_status', {
+            job_id: args.job_id,
+          })) as JobStatusResult;
+
+          if (status.state !== 'running') {
+            const output = await call(email, 'read_job_output', { job_id: args.job_id });
+            return asText({ ...status, waited_seconds: polls * (POLL_INTERVAL_MS / 1000), ...(output as object) });
+          }
+
+          if (Date.now() >= deadline) {
+            return asText({
+              ...status,
+              timed_out: true,
+              note: 'Still running. The job was left alone - wait again or check job_status later.',
+            });
+          }
+
+          polls++;
+          if (progressToken != null && extra?.sendNotification) {
+            /* No total: the duration is unknown, and a made-up one would read as a real estimate.
+             * Each notification resets the client's tool-call timeout, which is the point. */
+            await extra
+              .sendNotification({
+                method: 'notifications/progress',
+                params: {
+                  progressToken,
+                  progress: polls,
+                  message: `Waiting for job (${status.output_chars} characters of output so far)`,
+                },
+              })
+              .catch((err: unknown) => {
+                logger.debug({ err }, 'progress notification not delivered');
+              });
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        }
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'kill_job',
+    {
+      description:
+        'Terminate a running background job (SIGTERM to its process group). Its output stays readable afterwards.',
+      inputSchema: KillJobSchema.shape,
+    },
+    async (args, extra) => {
+      try {
+        const email = resolveEmail(extra);
+        return asText(await call(email, 'kill_job', { job_id: args.job_id }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+}

--- a/packages/mcp-linux/src/utils/cap-output.ts
+++ b/packages/mcp-linux/src/utils/cap-output.ts
@@ -1,0 +1,56 @@
+/**
+ * Caps terminal output before it goes back to the model.
+ *
+ * An uncapped `cat` or build log costs the whole conversation: the output is re-sent with every
+ * model call for the rest of the turn, and the provider's tokens-per-minute quota is what actually
+ * runs out (Scaleway answers 429 "INSUFFICIENT QUOTA" once a minute's worth is used up). Head and
+ * tail are what a reader needs - the command that ran and how it ended - so the middle is dropped
+ * and the model is told how to page the rest with read_terminal_output.
+ */
+
+const DEFAULT_MAX_OUTPUT_CHARS = 40_000;
+/** Below this a split into head and tail is pointless. */
+const MIN_SPLIT_CHARS = 400;
+
+export interface CappedOutput {
+  output: string;
+  /** Present only when something was dropped, so untruncated results stay clean. */
+  output_truncated?: true;
+  omitted_chars?: number;
+  total_chars?: number;
+}
+
+export function maxOutputChars(): number {
+  const configured = parseInt(process.env.MCP_LINUX_MAX_OUTPUT_CHARS || '', 10);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_MAX_OUTPUT_CHARS;
+}
+
+export function capOutput(text: string, limit: number = maxOutputChars()): CappedOutput {
+  if (text.length <= limit) {
+    return { output: text };
+  }
+
+  const omitted = text.length - limit;
+  const notice = `\n\n[... ${omitted} characters omitted. Read them with read_terminal_output using offset/length. ...]\n\n`;
+
+  if (limit < MIN_SPLIT_CHARS) {
+    return {
+      output: text.slice(0, limit) + notice,
+      output_truncated: true,
+      omitted_chars: omitted,
+      total_chars: text.length,
+    };
+  }
+
+  /* Two thirds head, one third tail: the start carries what the command was doing, the end carries
+   * the exit state and any error, which is usually the part being looked for. */
+  const headChars = Math.floor((limit * 2) / 3);
+  const tailChars = limit - headChars;
+
+  return {
+    output: text.slice(0, headChars) + notice + text.slice(text.length - tailChars),
+    output_truncated: true,
+    omitted_chars: omitted,
+    total_chars: text.length,
+  };
+}

--- a/packages/mcp-linux/src/worker/index.ts
+++ b/packages/mcp-linux/src/worker/index.ts
@@ -16,6 +16,7 @@ import { join, dirname } from 'node:path';
 import { createTerminalHandlers } from './terminal-handler.ts';
 import { createWorkspaceHandlers } from './workspace-handler.ts';
 import { createFilesystemHandlers } from './filesystem-handler.ts';
+import { createJobHandlers } from './job-handler.ts';
 import type { Handler, HandlerMap, WorkerContext, WorkerMethod } from './types.ts';
 
 // ── CLI Arguments ────────────────────────────────────────────────────────────
@@ -39,11 +40,13 @@ const ctx: WorkerContext = {
 const { handlers: terminalHandlers, shutdownTerminals } = createTerminalHandlers(ctx);
 const workspaceHandlers = createWorkspaceHandlers(ctx);
 const filesystemHandlers = createFilesystemHandlers(ctx);
+const jobHandlers = createJobHandlers(ctx);
 
 const handlers: HandlerMap = {
   ...terminalHandlers,
   ...workspaceHandlers,
   ...filesystemHandlers,
+  ...jobHandlers,
 } as HandlerMap;
 
 // ── IPC Server ───────────────────────────────────────────────────────────────

--- a/packages/mcp-linux/src/worker/job-handler.ts
+++ b/packages/mcp-linux/src/worker/job-handler.ts
@@ -1,0 +1,230 @@
+/**
+ * Background jobs: commands that outlive the tool call that started them.
+ *
+ * `execute_command` has to return within the MCP call timeout, which rules out installs, builds,
+ * long test runs and anything else that takes minutes. A job is started detached, so it keeps
+ * running while the agent does something else - or while the user is not even in the chat - and its
+ * output is collected in the user's home for later reading.
+ *
+ * State lives in files rather than in memory so a worker restart does not lose track of a running
+ * job: `<id>.json` holds the metadata, `<id>.log` the combined output, `<id>.exit` the exit code
+ * once the command is done. The exit file is what makes "finished" observable without a parent
+ * process watching.
+ */
+
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { Handler, WorkerContext } from './types.ts';
+import { capOutput } from '../utils/cap-output.ts';
+import { escapeForDoubleQuotedShell } from './git-utils.ts';
+
+const JOBS_DIR_NAME = '.mcp_jobs';
+/** Keeps `list_jobs` readable and the directory from growing without bound. */
+const MAX_LISTED_JOBS = 50;
+
+interface JobMeta {
+  job_id: string;
+  command: string;
+  workspace: string;
+  pid: number;
+  started_at: string;
+}
+
+type JobState = 'running' | 'finished' | 'failed' | 'unknown';
+
+export interface JobStatus extends JobMeta {
+  state: JobState;
+  exit_code: number | null;
+  finished_at: string | null;
+  output_chars: number;
+}
+
+function jobsDir(ctx: WorkerContext): string {
+  return join(ctx.homeDir, JOBS_DIR_NAME);
+}
+
+function validateJobId(jobId: unknown): string {
+  if (typeof jobId !== 'string' || !/^[0-9a-f-]{36}$/.test(jobId)) {
+    throw new Error('job_id is required and must be a job id returned by start_job');
+  }
+  return jobId;
+}
+
+async function readMeta(ctx: WorkerContext, jobId: string): Promise<JobMeta> {
+  try {
+    return JSON.parse(await fs.readFile(join(jobsDir(ctx), `${jobId}.json`), 'utf-8')) as JobMeta;
+  } catch {
+    throw new Error(`Job not found: ${jobId}`);
+  }
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    /* Signal 0 only checks for existence and permission, it does not touch the process. */
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function statusOf(ctx: WorkerContext, meta: JobMeta): Promise<JobStatus> {
+  const dir = jobsDir(ctx);
+  let exitCode: number | null = null;
+  let finishedAt: string | null = null;
+
+  try {
+    const exitFile = join(dir, `${meta.job_id}.exit`);
+    const raw = await fs.readFile(exitFile, 'utf-8');
+    const parsed = parseInt(raw.trim(), 10);
+    exitCode = Number.isFinite(parsed) ? parsed : null;
+    finishedAt = (await fs.stat(exitFile)).mtime.toISOString();
+  } catch {
+    /* No exit file yet: either still running, or killed before it could write one. */
+  }
+
+  let outputChars = 0;
+  try {
+    outputChars = (await fs.stat(join(dir, `${meta.job_id}.log`))).size;
+  } catch {
+    /* No output yet. */
+  }
+
+  let state: JobState;
+  if (exitCode !== null) {
+    state = exitCode === 0 ? 'finished' : 'failed';
+  } else if (processAlive(meta.pid)) {
+    state = 'running';
+  } else {
+    /* Gone without an exit code - killed, or the container restarted under it. */
+    state = 'unknown';
+  }
+
+  return { ...meta, state, exit_code: exitCode, finished_at: finishedAt, output_chars: outputChars };
+}
+
+export function createJobHandlers(ctx: WorkerContext): Record<string, Handler> {
+  return {
+    async start_job(params) {
+      const command = params.command as string;
+      const workspace = (params.workspace as string) || 'default';
+      if (typeof command !== 'string' || !command.trim()) {
+        throw new Error('command is required');
+      }
+
+      const dir = jobsDir(ctx);
+      await fs.mkdir(dir, { recursive: true });
+
+      const jobId = randomUUID();
+      const logPath = join(dir, `${jobId}.log`);
+      const exitPath = join(dir, `${jobId}.exit`);
+      const workspaceRoot = join(ctx.workspacesDir, workspace);
+
+      /* The wrapper is what makes completion observable: whatever the command does, the exit code
+       * lands in a file the status check can read without supervising the process.
+       * A subshell, not a brace group - a command containing `exit` would otherwise end the whole
+       * wrapper and the exit code would never be written. */
+      const wrapped = `( ${command} ) > "${escapeForDoubleQuotedShell(logPath)}" 2>&1; echo $? > "${escapeForDoubleQuotedShell(exitPath)}"`;
+
+      const child = spawn('bash', ['-lc', wrapped], {
+        cwd: workspaceRoot,
+        detached: true,
+        stdio: 'ignore',
+      });
+      child.unref();
+
+      if (child.pid == null) {
+        throw new Error('Failed to start the job');
+      }
+
+      const meta: JobMeta = {
+        job_id: jobId,
+        command,
+        workspace,
+        pid: child.pid,
+        started_at: new Date().toISOString(),
+      };
+      await fs.writeFile(join(dir, `${jobId}.json`), JSON.stringify(meta), 'utf-8');
+
+      return { ...meta, state: 'running' as const };
+    },
+
+    async list_jobs(params) {
+      const workspace = params.workspace as string | undefined;
+      const dir = jobsDir(ctx);
+
+      let entries: string[];
+      try {
+        entries = await fs.readdir(dir);
+      } catch {
+        return { jobs: [], total: 0 };
+      }
+
+      const jobIds = entries.filter((f) => f.endsWith('.json')).map((f) => f.slice(0, -5));
+      const all: JobStatus[] = [];
+      for (const jobId of jobIds) {
+        try {
+          all.push(await statusOf(ctx, await readMeta(ctx, jobId)));
+        } catch {
+          /* Half-written or removed while listing - not worth failing the whole list over. */
+        }
+      }
+
+      const filtered = workspace ? all.filter((j) => j.workspace === workspace) : all;
+      filtered.sort((a, b) => b.started_at.localeCompare(a.started_at));
+      return { jobs: filtered.slice(0, MAX_LISTED_JOBS), total: filtered.length };
+    },
+
+    async job_status(params) {
+      return statusOf(ctx, await readMeta(ctx, validateJobId(params.job_id)));
+    },
+
+    async read_job_output(params) {
+      const jobId = validateJobId(params.job_id);
+      const offset = (params.offset as number) || 0;
+      const length = params.length as number | undefined;
+      const status = await statusOf(ctx, await readMeta(ctx, jobId));
+
+      let full = '';
+      try {
+        full = await fs.readFile(join(jobsDir(ctx), `${jobId}.log`), 'utf-8');
+      } catch {
+        /* Nothing written yet. */
+      }
+
+      const slice = length ? full.slice(offset, offset + length) : full.slice(offset);
+      return {
+        job_id: jobId,
+        state: status.state,
+        exit_code: status.exit_code,
+        total_chars: full.length,
+        ...(length ? { output: slice } : capOutput(slice)),
+      };
+    },
+
+    async kill_job(params) {
+      const jobId = validateJobId(params.job_id);
+      const meta = await readMeta(ctx, jobId);
+      const status = await statusOf(ctx, meta);
+
+      if (status.state !== 'running') {
+        return { job_id: jobId, killed: false, state: status.state };
+      }
+
+      try {
+        /* Negative pid targets the process group, so a pipeline dies with its parent. */
+        process.kill(-meta.pid, 'SIGTERM');
+      } catch {
+        try {
+          process.kill(meta.pid, 'SIGTERM');
+        } catch {
+          return { job_id: jobId, killed: false, state: 'unknown' as const };
+        }
+      }
+
+      return { job_id: jobId, killed: true, state: 'unknown' as const };
+    },
+  };
+}

--- a/packages/mcp-linux/src/worker/terminal-handler.ts
+++ b/packages/mcp-linux/src/worker/terminal-handler.ts
@@ -7,6 +7,7 @@ import { join, relative } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { validateTerminalId } from '../utils/security.ts';
 import { stripAnsi } from '../utils/strip-ansi.ts';
+import { capOutput } from '../utils/cap-output.ts';
 import { escapeForDoubleQuotedShell, getGitMetadata } from './git-utils.ts';
 import { resolveWorkspacePath } from './workspace-utils.ts';
 import {
@@ -188,7 +189,7 @@ export function createTerminalHandlers(ctx: WorkerContext): {
 
       return {
         terminal_id: terminalId,
-        output: stripAnsi(newOutput),
+        ...capOutput(stripAnsi(newOutput)),
         workspace,
         cwd,
         cwd_relative_to_workspace: cwdRelative || undefined,
@@ -213,9 +214,11 @@ export function createTerminalHandlers(ctx: WorkerContext): {
       const slice = length ? fullOutput.slice(offset, offset + length) : fullOutput.slice(offset);
       const meta = await getGitMetadata(ctx.workspacesDir, session.workspace);
 
+      /* An explicit length is a deliberate page and is returned as asked; an open-ended read is
+       * capped like any other output, since it would otherwise pull the whole scrollback. */
       return {
         terminal_id: terminalId,
-        output: stripAnsi(slice),
+        ...(length ? { output: stripAnsi(slice) } : capOutput(stripAnsi(slice))),
         total_length: fullOutput.length,
         ...meta,
       };
@@ -244,7 +247,7 @@ export function createTerminalHandlers(ctx: WorkerContext): {
 
       return {
         terminal_id: terminalId,
-        output: stripAnsi(newOutput),
+        ...capOutput(stripAnsi(newOutput)),
         ...meta,
       };
     },

--- a/packages/mcp-linux/src/worker/types.ts
+++ b/packages/mcp-linux/src/worker/types.ts
@@ -33,7 +33,13 @@ export type WorkerMethod =
   | 'write_file'
   | 'edit_file'
   | 'grep'
-  | 'glob';
+  | 'glob'
+  // Background jobs
+  | 'start_job'
+  | 'list_jobs'
+  | 'job_status'
+  | 'read_job_output'
+  | 'kill_job';
 
 export type HandlerMap = Record<WorkerMethod, Handler>;
 

--- a/packages/mcp-linux/test/integration.ts
+++ b/packages/mcp-linux/test/integration.ts
@@ -173,4 +173,33 @@ function runTests(): void {
   console.log('\n=== All tests passed ===');
 }
 
+/** Content-based text detection, exercised against real files. */
+async function runFileTypeTests(): Promise<void> {
+  const { mkdtemp, writeFile } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const { looksLikeText } = await import('../src/tools/file.ts');
+
+  const dir = await mkdtemp(join(tmpdir(), 'mcp-linux-filetype-'));
+
+  const cases: Array<[string, Buffer | string, boolean]> = [
+    ['env.prod.example', 'DOMAIN=localhost\nPORT=3080\n', true],
+    ['Dockerfile.tpl', 'FROM node:24\nRUN echo hi\n', true],
+    ['empty.unknown', '', true],
+    ['binary.bin', Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01, 0x02, 0x03]), false],
+    ['control.bin', Buffer.from(Array.from({ length: 200 }, (_, i) => (i % 2 ? 0x01 : 0x41))), false],
+  ];
+
+  for (const [name, content, expected] of cases) {
+    const path = join(dir, name);
+    await writeFile(path, content);
+    const result = await looksLikeText(path);
+    assert(result === expected, `looksLikeText(${name}): expected ${expected}, got ${result}`);
+  }
+  assert((await looksLikeText(join(dir, 'missing.file'))) === false, 'looksLikeText: missing file is not text');
+  console.log('✓ looksLikeText: .example and .tpl read as text, NUL and control bytes do not');
+}
+
 runTests();
+await runFileTypeTests();
+console.log('=== File-type tests passed ===');

--- a/packages/mcp-linux/test/integration.ts
+++ b/packages/mcp-linux/test/integration.ts
@@ -7,6 +7,7 @@
 
 import { deriveUsername, addUsernameSuffix, sanitizeWorkspaceName, validateWorkspaceName } from '../src/utils/security.ts';
 import { extractUserContext } from '../src/utils/http-server.ts';
+import { capOutput } from '../src/utils/cap-output.ts';
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -131,6 +132,42 @@ function runTests(): void {
     const context = extractUserContext({ 'x-user-github-pat': 'ghp_usertoken' } as never);
     assert(context === null, 'extractUserContext: email stays required');
     console.log('✓ extractUserContext: a token without an email is not a user context');
+  }
+
+  // ── capOutput ───────────────────────────────────────────────────────────────
+
+  {
+    const result = capOutput('short output', 1000);
+    assert(result.output === 'short output', 'capOutput: below the limit stays untouched');
+    assert(result.output_truncated === undefined, 'capOutput: no truncation marker when unneeded');
+    assert(result.omitted_chars === undefined, 'capOutput: no counters when unneeded');
+    console.log('✓ capOutput: output below the limit is returned unchanged');
+  }
+
+  {
+    const text = 'A'.repeat(500) + 'MIDDLE' + 'B'.repeat(500);
+    const result = capOutput(text, 600);
+    assert(result.output_truncated === true, 'capOutput: marks truncation');
+    assert(result.omitted_chars === text.length - 600, `capOutput: omitted count, got ${result.omitted_chars}`);
+    assert(result.total_chars === text.length, 'capOutput: reports the original size');
+    assert(result.output.startsWith('A'), 'capOutput: keeps the head');
+    assert(result.output.endsWith('B'), 'capOutput: keeps the tail');
+    assert(!result.output.includes('MIDDLE'), 'capOutput: drops the middle');
+    assert(result.output.includes('read_terminal_output'), 'capOutput: says how to page the rest');
+    console.log('✓ capOutput: keeps head and tail, drops the middle, points at paging');
+  }
+
+  {
+    const result = capOutput('X'.repeat(1000), 100);
+    assert(result.output.startsWith('X'.repeat(100)), 'capOutput: tiny limit keeps the head only');
+    assert(result.omitted_chars === 900, 'capOutput: tiny limit counts correctly');
+    console.log('✓ capOutput: a limit too small to split keeps the head');
+  }
+
+  {
+    const exact = 'Y'.repeat(500);
+    assert(capOutput(exact, 500).output_truncated === undefined, 'capOutput: exact length is not truncated');
+    console.log('✓ capOutput: output exactly at the limit is not truncated');
   }
 
   console.log('\n=== All tests passed ===');

--- a/packages/mcp-linux/test/jobs.mjs
+++ b/packages/mcp-linux/test/jobs.mjs
@@ -1,0 +1,112 @@
+/**
+ * Background job test, driven through the official MCP SDK client - the same client LibreChat uses,
+ * so what passes here is what LibreChat gets.
+ *
+ * Needs a running server. Inside the container:
+ *   podman exec <container> node test/jobs.mjs
+ * Against a published port:
+ *   MCP_URL=http://127.0.0.1:3015/mcp node test/jobs.mjs
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const MCP_URL = process.env.MCP_URL || 'http://127.0.0.1:3015/mcp';
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+}
+
+const json = (result) => JSON.parse(result.content[0].text);
+
+const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+  requestInit: {
+    headers: {
+      'X-User-Email': 'job.suite@example.com',
+      'X-User-ID': 'job-suite',
+      'X-User-Username': 'jobsuite',
+    },
+  },
+});
+const client = new Client({ name: 'mcp-linux-job-test', version: '1.0.0' });
+await client.connect(transport);
+
+console.log('=== background jobs ===\n');
+
+{
+  const names = (await client.listTools()).tools.map((t) => t.name);
+  for (const tool of ['start_job', 'job_status', 'read_job_output', 'wait_for_job', 'list_jobs', 'kill_job']) {
+    assert(names.includes(tool), `${tool} is registered`);
+  }
+  console.log('✓ all six job tools are exposed');
+}
+
+{
+  const started = json(await client.callTool({ name: 'start_job', arguments: { command: 'sleep 1; echo started-fine' } }));
+  assert(/^[0-9a-f-]{36}$/.test(started.job_id), 'start_job returns a job id');
+  assert(started.state === 'running', 'a fresh job is running');
+  assert(typeof started.pid === 'number', 'start_job reports the pid');
+  console.log('✓ start_job returns immediately with a job id');
+}
+
+{
+  /* A client timeout far shorter than the job: it must survive on progress notifications alone,
+   * which is exactly how LibreChat runs tool calls (resetTimeoutOnProgress). */
+  const started = json(await client.callTool({ name: 'start_job', arguments: { command: 'sleep 6; echo slow-job-done; exit 3' } }));
+  let progress = 0;
+  const result = json(
+    await client.callTool(
+      { name: 'wait_for_job', arguments: { job_id: started.job_id, timeout_seconds: 30 } },
+      undefined,
+      { onprogress: () => { progress++; }, timeout: 4000, resetTimeoutOnProgress: true },
+    ),
+  );
+
+  assert(progress >= 2, `progress notifications keep the call alive, got ${progress}`);
+  assert(result.state === 'failed', `non-zero exit is reported as failed, got ${result.state}`);
+  assert(result.exit_code === 3, `exit code survives an exit inside the command, got ${result.exit_code}`);
+  assert(/slow-job-done/.test(result.output), 'output is returned with the result');
+  console.log(`✓ wait_for_job outlives a 4s client timeout (${progress} progress events) and reports exit 3`);
+}
+
+{
+  const started = json(await client.callTool({ name: 'start_job', arguments: { command: 'sleep 120' } }));
+  const killed = json(await client.callTool({ name: 'kill_job', arguments: { job_id: started.job_id } }));
+  assert(killed.killed === true, 'kill_job terminates a running job');
+
+  const after = json(await client.callTool({ name: 'job_status', arguments: { job_id: started.job_id } }));
+  assert(after.state !== 'running', `a killed job is no longer running, got ${after.state}`);
+  console.log('✓ kill_job stops a running job');
+}
+
+{
+  const started = json(await client.callTool({ name: 'start_job', arguments: { command: "python3 -c \"print('X'*200000)\"" } }));
+  await client.callTool({ name: 'wait_for_job', arguments: { job_id: started.job_id, timeout_seconds: 60 } }, undefined, {
+    onprogress: () => {},
+    resetTimeoutOnProgress: true,
+  });
+
+  const capped = json(await client.callTool({ name: 'read_job_output', arguments: { job_id: started.job_id } }));
+  assert(capped.output_truncated === true, 'large job output is capped');
+  assert(capped.output.length < capped.total_chars, 'capped output is shorter than the whole log');
+
+  const paged = json(await client.callTool({ name: 'read_job_output', arguments: { job_id: started.job_id, offset: 10, length: 25 } }));
+  assert(paged.output.length === 25, `an explicit length is honoured, got ${paged.output.length}`);
+  console.log('✓ read_job_output caps by default and pages on request');
+}
+
+{
+  const listed = json(await client.callTool({ name: 'list_jobs', arguments: {} }));
+  assert(listed.total >= 4, `list_jobs sees the jobs from this run, got ${listed.total}`);
+  const timestamps = listed.jobs.map((j) => j.started_at);
+  assert(
+    timestamps.every((t, i) => i === 0 || timestamps[i - 1] >= t),
+    'list_jobs returns newest first',
+  );
+  console.log('✓ list_jobs reports every job, newest first');
+}
+
+await client.close();
+console.log('\n=== All tests passed ===');


### PR DESCRIPTION
The Assistant kept failing with `429 "INSUFFICIENT QUOTA"`. Root cause and three fixes, plus the background-CLI capability that was missing.

## Why it failed

Scaleway rate-limits **per organization**: `x-ratelimit-limit-tokens: 200000` per minute, identical for every model we use (measured on glm-5.2, qwen3-235b, mistral-small-3.2). Reproduced against the live endpoint - a 210k-token prompt returns:

```
429 {"error":"INSUFFICIENT QUOTA","message":"You exceeded your current quota of tokens per minute."}
```

The Assistant was configured with `maxContextTokens: 262144`, Faktencheck with 250000 - both **above** the quota. Once a conversation grew past it, every request failed and stayed failing: no retry can make an oversized request fit, and the agents package hardcodes `maxRetries: 0` on the OpenAI-compatible path. That is exactly the screenshot behaviour where "weiter" fails again instantly.

Three multipliers made it hit sooner than the raw number suggests: an agent turn re-sends the whole context **once per tool round**; terminal output was uncapped; and a single `read_workspace_file` inlined up to 1 MB (~250k tokens).

## Fixes

- **Caps below the quota, not at the model window.** Assistant 64000 (room for three tool rounds in a minute), Faktencheck 96000. LibreChat truncates old messages instead of building a request that cannot be served.
- **Terminal output capped** at 40000 chars (`MCP_LINUX_MAX_OUTPUT_CHARS`), head two thirds + tail one third, omitted count included. Verified live: 200251 chars come back as 40097.
- **File reads paged.** 1200 lines by default with a `[lines X-Y of Z]` header and `offset`/`limit` to continue. Explicit `line_ranges` still honoured as given.

The real fix is a higher Scaleway quota - this makes the failure rare instead of permanent. Documented in `docs/LIBRECHAT_FEATURES.md`.

## Background jobs (the "run a CLI in the background and tell me when it's done" ask)

`start_job` spawns detached and returns a `job_id` immediately; the job outlives the tool call and the turn. `job_status`, `read_job_output`, `list_jobs`, `kill_job` manage it. `wait_for_job` blocks until the job ends while emitting `notifications/progress` every 2s, and the client resets its tool-call timeout on each one (LibreChat sets `resetTimeoutOnProgress: true`) - so a wait of minutes is legitimate.

State is files (`~/.mcp_jobs/<id>.{json,log,exit}`), not memory, so a worker restart does not lose a running job. The command runs in a subshell, so an `exit N` inside it still lets the wrapper record the code - a brace group let `exit` kill the wrapper and the job stayed `unknown` forever.

This required SSE responses (`enableJsonResponse` dropped): a JSON response is one body with no room for notifications. `tools/list` and `execute_command` re-checked through the SDK client afterwards.

**What is not possible, and why:** nothing can wake the agent between turns. LibreChat registers exactly one server-initiated notification handler (`resources/list_changed`, which only refreshes a list) and its agent loop has no entry point for an unsolicited event. So "notify me when it's done" works *within* a turn via `wait_for_job`, or by the agent checking `list_jobs` when the user writes again. A real push would need LibreChat to consume MCP notifications and re-invoke the agent - upstream does not handle even `tools/list_changed` yet (danny-avila/LibreChat#7117). The server instructions say this plainly so the agent does not promise something it cannot do.

## On the tool ergonomics

Less to do than expected: `edit` already enforces a unique `old_string` with a `replace_all` escape hatch, `grep`/`glob` already run ripgrep with limits, reads already carry line numbers, and `todowrite` exists. The gaps were the ones above - unbounded output and unbounded reads - plus no way to run anything long.

## Tests

- `test/jobs.mjs` (new) driven through the **official SDK client**, the same one LibreChat uses: all six tools exposed; `start_job` returns at once; `wait_for_job` outlives a 4s client timeout on 3 progress events and reports exit 3; `kill_job` stops a running job; `read_job_output` caps by default and pages on request; `list_jobs` newest first. 6/6 pass in the container.
- `test/integration.ts`: `capOutput` unit cases (below limit untouched, head+tail with the middle dropped, limit too small to split, exact length).
- Live MCP call: a command producing 200251 characters returns 40097.