### PR TITLE
fix(librechat): mail server title broke the config schema, prod would not start

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     ],
     "scripts": {
         "setup": "./scripts/setup-env.ts",
+        "validate:config": "./scripts/validate-librechat-config.ts",
         "setup:yes": "./scripts/setup-env.ts --yes",
         "setup:prod": "./scripts/setup-env.ts --prod",
         "setup:prod:yes": "./scripts/setup-env.ts --prod --yes",

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -943,7 +943,9 @@ mcpServers:
     # accounts and workspaces (attachments land in a workspace) while LibreChat treats
     # this as a separate server with its own tool list and its own credentials.
     url: http://$${STACK_NAME:-prod}-mcp-linux:3015/mcp/mail
-    title: E-Mail
+    # Letters, numbers and spaces only - LibreChat validates mcpServers.*.title against
+    # /^[a-zA-Z0-9 ]+$/ and refuses to start on anything else, hyphens included.
+    title: Postfach
     description: Eigenes Postfach lesen, durchsuchen und beantworten (IMAP/SMTP)
     iconPath: /images/mcp-mail-icon.svg
     initTimeout: 120000
@@ -967,7 +969,7 @@ mcpServers:
       # Address and password are required, so the tools stay hidden until the account is
       # set up - unlike the Linux server, none of them mean anything without a mailbox.
       MAIL_ADDRESS:
-        title: E-Mail-Adresse
+        title: Postfach-Adresse
         description: >-
           Deine eigene Adresse, z.B. vorname.nachname@correctiv.org. Von dieser Adresse
           wird gesendet, und dieses Postfach wird gelesen.

--- a/scripts/validate-librechat-config.ts
+++ b/scripts/validate-librechat-config.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env -S node --experimental-strip-types --experimental-transform-types --no-warnings
+
+/**
+ * Validates librechat.yaml against LibreChat's own Zod schema, for every
+ * environment, before the config can reach a container.
+ *
+ * This exists because a valid YAML file is not a valid config. LibreChat refuses
+ * to start on a schema violation - `mcpServers.*.title` for instance has to match
+ * /^[a-zA-Z0-9 ]+$/, so a hyphen in a display name is enough to crashloop the
+ * API - and the merge that init performs means the file that ships is not any of
+ * the files in the repo.
+ *
+ * The schema comes from the fork in dev/librechat, so what passes here is what
+ * the deployed image accepts. A schema change in the fork changes this check with
+ * it, which is the point.
+ *
+ *   npm run validate:config
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+/* The merge init performs, not a reimplementation of it - an override that merges
+ * differently here would validate a config nobody ever ships. */
+import { deepMerge } from '../packages/librechat-init/src/utils/merge.ts';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const CONFIG_DIR = join(ROOT, 'packages/librechat-init/config');
+const DATA_PROVIDER = join(
+  ROOT,
+  'dev/librechat/packages/data-provider/dist/index.js',
+);
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Fills in the placeholders so the schema sees the shape it will see in the
+ * container. init resolves `$${VAR:-default}` at build time and leaves `${VAR}`
+ * for LibreChat to resolve at load time, and neither form is a valid URL - which
+ * is what the schema checks. Names that read like a URL get a URL-shaped
+ * stand-in; everything else gets a hostname-safe token.
+ */
+function resolvePlaceholders(raw: string): string {
+  const substitute = (name: string, fallback: string | undefined): string => {
+    if (fallback != null && fallback !== '') {
+      return fallback;
+    }
+    return /URL|URI/.test(name)
+      ? 'https://placeholder.invalid'
+      : `placeholder-${name.toLowerCase().replace(/_/g, '-')}`;
+  };
+
+  return raw
+    .replace(/\$\$\{([A-Za-z0-9_]+)(?::-([^}]*))?\}/g, (_match, name, fallback) =>
+      substitute(name, fallback),
+    )
+    .replace(/\$\{([A-Za-z0-9_]+)(?::-([^}]*))?\}/g, (_match, name, fallback) =>
+      substitute(name, fallback),
+    );
+}
+
+function load(file: string): unknown {
+  return yaml.load(resolvePlaceholders(readFileSync(join(CONFIG_DIR, file), 'utf8')));
+}
+
+function main(): void {
+  if (!existsSync(DATA_PROVIDER)) {
+    console.error(
+      `Cannot validate: ${DATA_PROVIDER} is missing.\nBuild the fork first: npm run build:dev (or cd dev/librechat && npm run build).`,
+    );
+    process.exit(1);
+  }
+
+  const { configSchema } = require(DATA_PROVIDER) as {
+    configSchema: { safeParse: (value: unknown) => SafeParseResult };
+  };
+
+  const base = load('librechat.yaml');
+  let failed = false;
+
+  for (const env of ['local', 'dev', 'prod'] as const) {
+    const overrideFile = `librechat.${env}.yaml`;
+    const config = existsSync(join(CONFIG_DIR, overrideFile))
+      ? deepMerge(
+          base as Record<string, unknown>,
+          load(overrideFile) as Record<string, unknown>,
+        )
+      : base;
+
+    const result = configSchema.safeParse(config);
+    if (result.success) {
+      console.log(`✓ ${env}`);
+      continue;
+    }
+
+    failed = true;
+    console.error(`✗ ${env}`);
+    for (const issue of result.error.issues) {
+      console.error(`    ${issue.path.join('.')}: ${issue.message}`);
+    }
+  }
+
+  if (failed) {
+    console.error(
+      '\nLibreChat exits on these instead of starting. Fix them before deploying.',
+    );
+    process.exit(1);
+  }
+
+  console.log('\nAll environments validate against the deployed schema.');
+}
+
+interface SafeParseResult {
+  success: boolean;
+  error?: { issues: { path: (string | number)[]; message: string }[] };
+}
+
+main();


### PR DESCRIPTION
**Hotfix.** Prod startet nicht.

`title: E-Mail` fällt durch LibreChats eigene Validierung: `mcpServers.*.title` muss auf `/^[a-zA-Z0-9 ]+$/` passen, der Bindestrich reicht also, damit die API beim Laden aussteigt und in eine Crashloop geht.

```
error: Invalid custom config file at /app/config/librechat.yaml:
  mcpServers.mail.title: Title can only contain letters, numbers, and spaces
error: Exiting due to invalid configuration.
```

Mein Fehler: ich habe die YAML-Syntax geprüft und nie gegen das Schema, das den Start entscheidet. Titel ist jetzt `Postfach`, mit der Einschränkung als Kommentar an der Zeile.

## Der Rest ist die Prüfung, die das verhindert hätte

`npm run validate:config` schickt `librechat.yaml` plus jedes Environment-Override durch LibreChats `configSchema` - das aus dem Fork in `dev/librechat`, also genau das, was das deployte Image akzeptiert - und meldet jedes Problem mit Pfad:

```
✓ local
✓ dev
✓ prod

All environments validate against the deployed schema.
```

Zwei Details, die es erst belastbar machen:

- Es benutzt **init's eigenes `deepMerge`**, keine Nachbildung. Eine Merge-Semantik, die hier anders wäre, würde eine Config validieren, die nie ausgeliefert wird - beim ersten Versuch mit einem naiven Merge fielen prompt zwei falsche Fehler an `endpoints.custom` an.
- Es füllt die `$${VAR}`-Platzhalter so, wie init es tut, damit URL-Felder URLs sehen.

Gegenprobe in beide Richtungen: grün auf diesem Commit, und mit dem Bindestrich zurück fallen alle drei Umgebungen mit genau der Meldung durch, die in den Prod-Logs stand.

## Noch offen

Der Aufruf hängt an einem npm-Skript, nicht an der CI - dafür bräuchte der Workflow das gebaute `data-provider` aus dem Fork. Lege ich als Issue nach; jetzt zählt, dass prod wieder läuft.