### PR TITLE
fix(librechat): restore the E-Mail-Adresse label

### DIFF
--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -969,7 +969,7 @@ mcpServers:
       # Address and password are required, so the tools stay hidden until the account is
       # set up - unlike the Linux server, none of them mean anything without a mailbox.
       MAIL_ADDRESS:
-        title: Postfach-Adresse
+        title: E-Mail-Adresse
         description: >-
           Deine eigene Adresse, z.B. vorname.nachname@correctiv.org. Von dieser Adresse
           wird gesendet, und dieses Postfach wird gelesen.


### PR DESCRIPTION
Zweiter Versuch für #95, das leer gemergt ist.

Aus #94 hat das sed, das den Server-Titel zurückgestellt hat, das customUserVar-Label als Teilstring mitgenommen: `E-Mail-Adresse` wurde zu `Postfach-Adresse`. Nur `mcpServers.*.title` ist auf Buchstaben, Zahlen und Leerzeichen beschränkt, die Variablen-Labels sind freier Text.

Warum #95 nichts bewirkt hat: sein Branch kam vom Hotfix-Branch statt von `main`. Der Squash-Commit `f911df0` änderte deshalb keine Datei, es lief kein Build, und das Label blieb stehen. Dieser Branch kommt aus `main` und der Diff ist nachweislich eine Zeile.

`npm run validate:config` grün für local, dev und prod.