### PR TITLE
fix(mcp-linux): stop evicting sessions whose client is still connected

### DIFF
--- a/docs/MCP_LINUX.md
+++ b/docs/MCP_LINUX.md
@@ -235,6 +235,8 @@ When a request references a missing session (e.g. after restart), the server ret
 
 Sessions that have no activity for **MCP_LINUX_SESSION_IDLE_TIMEOUT_MIN** minutes are evicted periodically (every 5 min) to avoid unbounded growth when clients disconnect without sending DELETE.
 
+**A client holding its SSE stream open is never evicted**, however long ago it last sent a request. LibreChat opens that stream once and then keeps it, so measuring idleness as "time since the last request" used to evict live connections: prod logged `404 with active session - session lost, triggering reconnection` for every user every 35 minutes (30 min timeout + the 5 min cleanup tick), followed by two failed reconnects before the client rebuilt the transport. `/health` reports `openStreams` so this is observable from outside.
+
 ### Prod and dev on the same Portainer host
 
 All services already use **STACK_NAME** in names: `container_name: ${STACK_NAME:-prod}-<service>`, networks like `${STACK_NAME:-prod}-app-net`, volumes like `${STACK_NAME:-prod}-mcp-linux-homes`. So set **STACK_NAME=dev** for the dev stack so prod and dev get separate networks/volumes/containers.
@@ -264,7 +266,7 @@ If you run **both** stacks on one host they also share the external network `loa
 | `MCP_LINUX_UPLOAD_SESSION_TIMEOUT_MIN` | `15` | Upload session expiry (min) |
 | `MCP_LINUX_DOWNLOAD_BASE_URL` | *(falls back to upload URL)* | Public base URL for download links |
 | `MCP_LINUX_DOWNLOAD_SESSION_TIMEOUT_MIN` | `60` | Download link expiry (min) |
-| `MCP_LINUX_SESSION_IDLE_TIMEOUT_MIN` | `30` | MCP session idle timeout (min); sessions with no activity are evicted to prevent leak |
+| `MCP_LINUX_SESSION_IDLE_TIMEOUT_MIN` | `30` | Idle timeout (min) for sessions with **no open SSE stream**; a connected client is exempt |
 | `MCP_LINUX_STATUS_MAX_FILES` | `50` | Max file entries per status category (staged/unstaged/untracked) before capping |
 | `MCP_LINUX_STATUS_COLLAPSE_DIRS` | `uploads,venv,.venv` | Comma-separated dirs whose paths are collapsed to one summary line in status |
 | `MCP_LINUX_RESOURCE_LIST_DIRS` | `uploads,outputs` | Comma-separated dirs listed in MCP resources (allowlist); only these appear in list |

--- a/packages/librechat-init/config/librechat.yaml
+++ b/packages/librechat-init/config/librechat.yaml
@@ -969,7 +969,7 @@ mcpServers:
       # Address and password are required, so the tools stay hidden until the account is
       # set up - unlike the Linux server, none of them mean anything without a mailbox.
       MAIL_ADDRESS:
-        title: Postfach-Adresse
+        title: E-Mail-Adresse
         description: >-
           Deine eigene Adresse, z.B. vorname.nachname@correctiv.org. Von dieser Adresse
           wird gesendet, und dieses Postfach wird gelesen.

--- a/packages/mcp-linux/src/server.ts
+++ b/packages/mcp-linux/src/server.ts
@@ -22,6 +22,7 @@ import {
   setupHealthEndpoint,
   setupGracefulShutdown,
   extractUserContext,
+  idleSessionIds,
 } from './utils/http-server.ts';
 import { UserManager } from './user-manager.ts';
 import { WorkerManager } from './worker-manager.ts';
@@ -58,6 +59,14 @@ const mailTransports = new Map<string, StreamableHTTPServerTransport>();
 const calendarTransports = new Map<string, StreamableHTTPServerTransport>();
 /** Last activity timestamp per session (for idle timeout and leak prevention) */
 const sessionLastActivity = new Map<string, number>();
+/**
+ * Sessions whose client currently holds its SSE stream open. They are exempt
+ * from the idle timeout: LibreChat opens the stream once and then keeps it, so
+ * measuring idleness as "time since the last request" evicted connections that
+ * were very much alive - the client answered every timeout with
+ * "session lost, triggering reconnection".
+ */
+const openStreams = new Set<string>();
 
 // Shared managers (singleton per container)
 const userManager = new UserManager();
@@ -177,6 +186,7 @@ function createSession(): { server: McpServer; transport: StreamableHTTPServerTr
       transports.delete(sid);
       sessionEmailMap.delete(sid);
       sessionLastActivity.delete(sid);
+      openStreams.delete(sid);
     }
   };
 
@@ -209,6 +219,7 @@ function createExtraSession(
       logger.info({ sessionId: sid, label, totalSessions: sessions.size - 1 }, 'Session closed');
       sessions.delete(sid);
       sessionLastActivity.delete(sid);
+      openStreams.delete(sid);
     }
   };
 
@@ -273,6 +284,7 @@ async function createApp(): Promise<express.Application> {
       mail: mailTransports.size,
       calendar: calendarTransports.size,
     }),
+    openStreams: () => openStreams.size,
   });
 
   setupMcpEndpoints(app, {
@@ -283,6 +295,8 @@ async function createApp(): Promise<express.Application> {
     createServer: createSession,
     logger,
     onSessionActivity: (sessionId: string) => sessionLastActivity.set(sessionId, Date.now()),
+    onStreamOpen: (sessionId: string) => openStreams.add(sessionId),
+    onStreamClose: (sessionId: string) => openStreams.delete(sessionId),
   });
 
   setupMcpEndpoints(app, {
@@ -295,6 +309,8 @@ async function createApp(): Promise<express.Application> {
       createExtraSession('mail', () => createMailServer(userManager), mailTransports),
     logger,
     onSessionActivity: (sessionId: string) => sessionLastActivity.set(sessionId, Date.now()),
+    onStreamOpen: (sessionId: string) => openStreams.add(sessionId),
+    onStreamClose: (sessionId: string) => openStreams.delete(sessionId),
   });
 
   setupMcpEndpoints(app, {
@@ -307,6 +323,8 @@ async function createApp(): Promise<express.Application> {
       createExtraSession('calendar', createCalendarServer, calendarTransports),
     logger,
     onSessionActivity: (sessionId: string) => sessionLastActivity.set(sessionId, Date.now()),
+    onStreamOpen: (sessionId: string) => openStreams.add(sessionId),
+    onStreamClose: (sessionId: string) => openStreams.delete(sessionId),
   });
 
   return app;
@@ -330,19 +348,20 @@ async function main(): Promise<void> {
     const sessionIdleTimeoutMs = sessionIdleTimeoutMin * 60 * 1000;
     const SESSION_CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // run every 5 min
     const sessionCleanupTimer = setInterval(() => {
-      const now = Date.now();
-      for (const [sessionId, lastActivity] of sessionLastActivity.entries()) {
-        if (now - lastActivity < sessionIdleTimeoutMs) continue;
-        /* One activity map covers both endpoints, so find which one owns the session. */
+      const stale = idleSessionIds({
+        lastActivity: sessionLastActivity,
+        openStreams,
+        idleTimeoutMs: sessionIdleTimeoutMs,
+        now: Date.now(),
+      });
+
+      for (const sessionId of stale) {
+        /* One activity map covers all endpoints, so find which one owns the session. */
         const owner = [transports, mailTransports, calendarTransports].find((map) =>
           map.has(sessionId),
         );
-        if (!owner) {
-          sessionLastActivity.delete(sessionId);
-          continue;
-        }
-        const t = owner.get(sessionId);
-        if (!t) {
+        const t = owner?.get(sessionId);
+        if (!owner || !t) {
           sessionLastActivity.delete(sessionId);
           continue;
         }
@@ -354,6 +373,7 @@ async function main(): Promise<void> {
         owner.delete(sessionId);
         sessionEmailMap.delete(sessionId);
         sessionLastActivity.delete(sessionId);
+        openStreams.delete(sessionId);
         logger.info(
           {
             sessionId,

--- a/packages/mcp-linux/src/utils/http-server.ts
+++ b/packages/mcp-linux/src/utils/http-server.ts
@@ -138,6 +138,43 @@ export interface HttpServerConfig {
   logger?: Logger;
   /** Called when a session is used (GET or POST with existing session). Used for idle timeout. */
   onSessionActivity?: (sessionId: string) => void;
+  /**
+   * Called when a client opens its SSE stream, and again when that stream ends.
+   *
+   * A client holding a stream open is present, however long ago it last sent a
+   * request, so the idle timeout must not reach it. Without this the server
+   * evicted live sessions on the clock and the client answered with
+   * "session lost, triggering reconnection" every idle timeout.
+   */
+  onStreamOpen?: (sessionId: string) => void;
+  onStreamClose?: (sessionId: string) => void;
+}
+
+/**
+ * Sessions to close because nothing has used them for too long.
+ *
+ * Split out from the interval that calls it so the policy can be asserted
+ * without waiting on a clock: pass a `now` and get back the verdict.
+ *
+ * Held-open streams are excluded. The timeout exists for clients that vanish
+ * without sending DELETE, and a client whose stream is still connected has not
+ * vanished - its stream ending is what puts it back in scope.
+ */
+export function idleSessionIds(args: {
+  lastActivity: Map<string, number>;
+  openStreams: ReadonlySet<string>;
+  idleTimeoutMs: number;
+  now: number;
+}): string[] {
+  const { lastActivity, openStreams, idleTimeoutMs, now } = args;
+  return [...lastActivity.entries()]
+    .filter(([sessionId, seen]) => {
+      if (openStreams.has(sessionId)) {
+        return false;
+      }
+      return now - seen >= idleTimeoutMs;
+    })
+    .map(([sessionId]) => sessionId);
 }
 
 /**
@@ -150,6 +187,8 @@ export function setupHealthEndpoint(
     serverName: string;
     version: string;
     sessionCounts: () => Record<string, number>;
+    /** Clients currently holding an SSE stream open, i.e. really connected. */
+    openStreams?: () => number;
   },
 ): void {
   app.get('/health', (_req: Request, res: Response) => {
@@ -160,6 +199,7 @@ export function setupHealthEndpoint(
       version: config.version,
       activeSessions: Object.values(counts).reduce((sum, n) => sum + n, 0),
       sessions: counts,
+      ...(config.openStreams != null ? { openStreams: config.openStreams() } : {}),
     });
   });
 }
@@ -169,6 +209,7 @@ export function setupHealthEndpoint(
  */
 export function setupMcpEndpoints(app: express.Application, config: HttpServerConfig): void {
   const { transports, createServer, logger, onSessionActivity } = config;
+  const { onStreamOpen, onStreamClose } = config;
   const path = config.path ?? '/mcp';
 
   // SSE stream endpoint (GET /mcp)
@@ -187,6 +228,14 @@ export function setupMcpEndpoints(app: express.Application, config: HttpServerCo
     }
 
     onSessionActivity?.(sessionId);
+    /* Registered before handing over to the transport, which does not return
+     * until the stream ends. 'close' fires on client disconnect as well as on a
+     * normal end, so the session becomes evictable again either way. */
+    onStreamOpen?.(sessionId);
+    res.on('close', () => {
+      onStreamClose?.(sessionId);
+      onSessionActivity?.(sessionId);
+    });
     try {
       await transport.handleRequest(req, res, null);
     } catch (error) {

--- a/packages/mcp-linux/test/endpoints.ts
+++ b/packages/mcp-linux/test/endpoints.ts
@@ -14,6 +14,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { createApp } from '../src/server.ts';
+import { idleSessionIds } from '../src/utils/http-server.ts';
 
 const PORT = 3996;
 
@@ -23,16 +24,84 @@ function assert(condition: unknown, message: string): void {
   }
 }
 
-async function toolsAt(path: string): Promise<string[]> {
+async function connect(path: string): Promise<Client> {
   const client = new Client({ name: 'mcp-endpoint-test', version: '1.0.0' });
   await client.connect(
     new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${PORT}${path}`), {
       requestInit: { headers: { 'X-User-Email': 'endpoint.suite@example.com' } },
     }),
   );
+  return client;
+}
+
+async function toolsAt(path: string): Promise<string[]> {
+  const client = await connect(path);
   const names = (await client.listTools()).tools.map((tool) => tool.name);
   await client.close();
   return names;
+}
+
+const health = async (): Promise<Record<string, any>> =>
+  (await (await fetch(`http://127.0.0.1:${PORT}/health`)).json()) as Record<string, any>;
+
+/** Polls until the predicate holds, so the assertion does not race the socket. */
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  what: string,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${what}`);
+}
+
+/**
+ * The idle-timeout policy, asserted without a clock. This is the bug that showed
+ * up in production as "404 with active session - session lost, triggering
+ * reconnection" every 35 minutes: a client that holds its stream open sends no
+ * requests, so measuring idleness by the last request evicted it while it was
+ * connected.
+ */
+function checkIdlePolicy(): void {
+  const minute = 60_000;
+  const now = 10 * minute;
+  const lastActivity = new Map([
+    ['fresh', now - minute],
+    ['stale', now - 31 * minute],
+    ['stale-but-streaming', now - 31 * minute],
+  ]);
+
+  const evicted = idleSessionIds({
+    lastActivity,
+    openStreams: new Set(['stale-but-streaming']),
+    idleTimeoutMs: 30 * minute,
+    now,
+  });
+
+  assert(evicted.includes('stale'), 'an idle session with no stream is evicted');
+  assert(!evicted.includes('fresh'), 'a recently used session is kept');
+  assert(
+    !evicted.includes('stale-but-streaming'),
+    'a session whose client holds the stream open is kept, however old its last request',
+  );
+  assert(evicted.length === 1, `exactly one eviction, got ${evicted.join(', ')}`);
+
+  /* Exactly at the timeout counts as idle - the boundary decides whether the
+   * cleanup ever fires at all for a client on a tidy interval. */
+  const atBoundary = idleSessionIds({
+    lastActivity: new Map([['edge', now - 30 * minute]]),
+    openStreams: new Set(),
+    idleTimeoutMs: 30 * minute,
+    now,
+  });
+  assert(atBoundary.length === 1, 'a session idle for exactly the timeout is evicted');
+
+  console.log('✓ idle eviction skips sessions whose stream is still open');
 }
 
 async function main(): Promise<void> {
@@ -60,13 +129,29 @@ async function main(): Promise<void> {
   assert(!calendar.includes('list_mailboxes'), 'the calendar server does not carry mail tools');
   console.log('✓ the tool lists stay separate, so credentials gate one server at a time');
 
-  const health = await (await fetch(`http://127.0.0.1:${PORT}/health`)).json();
-  assert(health.status === 'ok', 'health reports ok');
+  const report = await health();
+  assert(report.status === 'ok', 'health reports ok');
   assert(
-    'linux' in health.sessions && 'mail' in health.sessions && 'calendar' in health.sessions,
-    `health counts all three, got ${JSON.stringify(health.sessions)}`,
+    'linux' in report.sessions && 'mail' in report.sessions && 'calendar' in report.sessions,
+    `health counts all three, got ${JSON.stringify(report.sessions)}`,
   );
   console.log('✓ one health endpoint counts the sessions of all three');
+
+  checkIdlePolicy();
+
+  {
+    /* The policy above is only worth anything if the server actually reports a
+     * held-open stream, so drive it with a real client. */
+    const before = (await health()).openStreams;
+    assert(before === 0, `no streams before connecting, got ${before}`);
+
+    const client = await connect('/mcp');
+    await waitFor(async () => (await health()).openStreams === 1, 'the stream to register');
+
+    await client.close();
+    await waitFor(async () => (await health()).openStreams === 0, 'the stream to deregister');
+    console.log('✓ a connected client is counted as an open stream, and released on close');
+  }
 
   http.close();
   console.log('\n=== All tests passed ===');


### PR DESCRIPTION
Beim Nachsehen, ob die API nach dem Redeploy wirklich läuft, im Prod-Log gefunden. Alle 35 Minuten, für jeden Nutzer:

```
warn:  [MCP][linux] 404 with active session — session lost, triggering reconnection
error: [MCP][linux] Transport error (may require manual intervention): Failed to open SSE stream: Not Found
error: [MCP][linux] Transport error (may require manual intervention): Maximum reconnection attempts (2) exceeded
info:  [MCP][linux] Streamable-http transport closed
```

35 Minuten sind `MCP_LINUX_SESSION_IDLE_TIMEOUT_MIN` (30) plus der 5-Minuten-Takt der Aufräumschleife. Gemessen am Container: `IDLE=30`.

## Die Ursache ist die Definition von „idle"

LibreChat öffnet seinen SSE-Stream einmal und hält ihn dann. Es schickt danach keine Requests mehr, also wuchs „Zeit seit dem letzten Request" auf einer Verbindung, die die ganze Zeit lebendig war. Der Server hat sie geräumt, der Client bekam auf seinen eigenen Stream ein 404, hat die tote Session zweimal erneut probiert und erst dann den Transport neu gebaut.

Es heilt sich selbst - aber ein Tool-Aufruf, der in dieses Fenster fällt, schlägt fehl, und im Log stand „may require manual intervention" für etwas, an dem niemand eingreifen kann.

## Fix

Sessions mit offenem Stream sind vom Timeout ausgenommen. Das Ende des Streams - Client-Abbruch oder normales Ende, beides feuert `close` - holt sie zurück in den Geltungsbereich, das Leck, für das das Timeout existiert, bleibt also abgedeckt.

Die Policy steckt jetzt in `idleSessionIds`, einer Funktion, die `now` bekommt, damit sie ohne Uhr prüfbar ist:

- idle ohne Stream → geräumt
- kürzlich benutzt → behalten
- genau am Timeout → geräumt (die Grenze entscheidet, ob die Schleife überhaupt je greift)
- idle **mit** Stream → behalten

`/health` meldet zusätzlich `openStreams`. Der End-to-End-Test benutzt das, um zu prüfen, dass ein echter Client sich tatsächlich an- und abmeldet - die Policy allein wäre auch grün, wenn die Verdrahtung falsch wäre.

## Noch offen, separat

LibreChat probiert bei einem 404 zweimal dieselbe Session-Id, bevor es neu initialisiert. Die MCP-Spec (2025-11-25, §Session Management) sagt dazu *MUST start a new session*. Das ist ein Client-Fehler in unserem Fork und einen eigenen PR wert - er würde auch bei einem echten Server-Neustart die zwei Fehlerzeilen sparen. Dieser PR beseitigt die Ursache, nicht die Reaktion darauf.