### PR TITLE
ci: validate the config before the image and catch images that never got built

### DIFF
--- a/.github/workflows/build-librechat-init.yml
+++ b/.github/workflows/build-librechat-init.yml
@@ -19,6 +19,49 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # librechat.yaml ships inside this image, and LibreChat exits instead of
+      # starting when the file violates its schema. Validate before the image
+      # exists, not after it is deployed.
+      - name: Resolve the pinned LibreChat fork commit
+        id: fork
+        run: echo "sha=$(git rev-parse HEAD:dev/librechat)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out the LibreChat fork
+        # Only this one submodule, at the pinned commit. `submodules: true` would
+        # clone all fifteen of them for a config lint.
+        uses: actions/checkout@v4
+        with:
+          repository: faktenforum/LibreChat
+          ref: ${{ steps.fork.outputs.sha }}
+          path: dev/librechat
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          # This repo does not commit its own lockfile (see .gitignore), so the
+          # cache key hangs off the fork's, which is what the slow install needs.
+          cache-dependency-path: dev/librechat/package-lock.json
+
+      - name: Install the validator's dependencies
+        # Root only. The workspaces under packages/ are not needed to validate a
+        # config file, and installing them would put node_modules into the build
+        # context below.
+        run: npm install --workspaces=false --include-workspace-root --ignore-scripts --no-audit --no-fund
+
+      - name: Build the fork's config schema
+        # The validator requires data-provider's compiled configSchema. Building
+        # that one workspace avoids installing the whole LibreChat monorepo.
+        run: |
+          cd dev/librechat
+          npm ci --workspace packages/data-provider --ignore-scripts
+          npm run build --workspace packages/data-provider
+
+      - name: Validate librechat.yaml
+        run: npm run validate:config
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build-librechat.yml
+++ b/.github/workflows/build-librechat.yml
@@ -11,6 +11,8 @@ on:
       - dev/agents/**
       - .github/workflows/build-librechat.yml
       - .github/dockerfiles/librechat-with-agents.Dockerfile
+      # A url change here repoints the submodules this image is built from
+      - .gitmodules
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-mcp-db-timetable.yml
+++ b/.github/workflows/build-mcp-db-timetable.yml
@@ -7,6 +7,8 @@ on:
       - dev/db-timetable-mcp
       - dev/db-timetable-mcp/**
       - .github/workflows/build-mcp-db-timetable.yml
+      # A url change here repoints the submodule this image is built from
+      - .gitmodules
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-mcp-docs.yml
+++ b/.github/workflows/build-mcp-docs.yml
@@ -7,6 +7,8 @@ on:
       - dev/docs-mcp-server
       - dev/docs-mcp-server/**
       - .github/workflows/build-mcp-docs.yml
+      # A url change here repoints the submodule this image is built from
+      - .gitmodules
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-mcp-npm-search.yml
+++ b/.github/workflows/build-mcp-npm-search.yml
@@ -7,6 +7,8 @@ on:
       - dev/npm-search-mcp
       - dev/npm-search-mcp/**
       - .github/workflows/build-mcp-npm-search.yml
+      # A url change here repoints the submodule this image is built from
+      - .gitmodules
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-mcp-openstreetmap.yml
+++ b/.github/workflows/build-mcp-openstreetmap.yml
@@ -7,6 +7,8 @@ on:
       - dev/open-streetmap-mcp
       - dev/open-streetmap-mcp/**
       - .github/workflows/build-mcp-openstreetmap.yml
+      # A url change here repoints the submodule this image is built from
+      - .gitmodules
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-mcp-stackoverflow.yml
+++ b/.github/workflows/build-mcp-stackoverflow.yml
@@ -7,6 +7,8 @@ on:
       - dev/stackoverflow-mcp
       - dev/stackoverflow-mcp/**
       - .github/workflows/build-mcp-stackoverflow.yml
+      # A url change here repoints the submodule this image is built from
+      - .gitmodules
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/verify-images.yml
+++ b/.github/workflows/verify-images.yml
@@ -1,0 +1,43 @@
+name: Verify Published Images
+
+# Runs no docker build. It reads the org.opencontainers.image.revision label of
+# every :latest tag out of ghcr and fails if main has changes that the image was
+# never built from. Deliberately has no paths filter: the failure it catches is a
+# push whose diff matches no paths filter at all, so filtering it would blind it.
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Catches images that fell behind without a push of their own, e.g. a build
+    # that failed and nobody noticed.
+    - cron: '23 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # The check diffs against the commit each image was built from, which is
+          # older than a shallow clone reaches.
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        # Root only, and no lockfile to install from - this repo does not commit
+        # one. The check needs js-yaml and nothing else.
+        run: npm install --workspaces=false --include-workspace-root --ignore-scripts --no-audit --no-fund
+
+      - name: Verify every image against this commit
+        # On a push the builds for that same commit are still running, so give them
+        # time instead of reporting the race. Scheduled runs have nothing to wait for.
+        run: npm run verify:images -- --wait ${{ github.event_name == 'push' && '20' || '0' }}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "setup": "./scripts/setup-env.ts",
         "validate:config": "./scripts/validate-librechat-config.ts",
+        "verify:images": "./scripts/check-image-drift.ts",
         "setup:yes": "./scripts/setup-env.ts --yes",
         "setup:prod": "./scripts/setup-env.ts --prod",
         "setup:prod:yes": "./scripts/setup-env.ts --prod --yes",
@@ -51,8 +52,10 @@
     "license": "MIT",
     "devDependencies": {
         "@inquirer/prompts": "^8.3.2",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.0",
-        "dotenv": "^17.3.1"
+        "dotenv": "^17.3.1",
+        "js-yaml": "^4.1.1"
     },
     "overrides": {
         "hono": "^4.12.27",

--- a/scripts/check-image-drift.ts
+++ b/scripts/check-image-drift.ts
@@ -73,6 +73,19 @@ function toPathspec(pattern: string): string {
   return pattern.replace(/\/\*\*$/, '');
 }
 
+/**
+ * Watched by a workflow but never baked into its image, so a change here means
+ * "the recipe changed", not "the published image is stale".
+ *
+ * Both belong in the trigger - a workflow edit or a repointed submodule URL should
+ * produce a fresh build - but comparing against them retroactively marks every
+ * older image stale the moment either file is touched. This branch touching seven
+ * workflow files is exactly that case: it would have reported seven drifting
+ * images for a change that cannot reach any image. A check that is red on day one
+ * gets ignored, which would cost more than the coarseness it buys.
+ */
+const NOT_IMAGE_CONTENT = [':!.github', ':!.gitmodules'];
+
 function readTargets(): Target[] {
   const targets: Target[] = [];
 
@@ -193,7 +206,15 @@ function git(args: string[]): { status: number; stdout: string; stderr: string }
 }
 
 function driftingFiles(revision: string, ref: string, pathspecs: string[]): string[] {
-  const diff = git(['diff', '--name-only', revision, ref, '--', ...pathspecs]);
+  const diff = git([
+    'diff',
+    '--name-only',
+    revision,
+    ref,
+    '--',
+    ...pathspecs,
+    ...NOT_IMAGE_CONTENT,
+  ]);
   if (diff.status !== 0) {
     throw new Error(`git diff failed: ${diff.stderr.trim()}`);
   }
@@ -273,6 +294,16 @@ async function main(): Promise<void> {
   if (resolved.status !== 0) {
     console.error(`Cannot resolve ${ref}: ${resolved.stderr.trim()}`);
     process.exit(1);
+  }
+
+  /* Run on a ref that predates main and every image built from a later commit looks
+   * stale, because the diff reads those commits as absent. The workflow only runs
+   * this on main; a developer running it on a branch needs to know why. */
+  const behindMain = git(['merge-base', '--is-ancestor', 'origin/main', ref]);
+  if (behindMain.status === 1) {
+    console.error(
+      `Note: ${ref} does not contain origin/main, so images built from newer commits will be reported as drifting. Rebase before trusting this.\n`,
+    );
   }
 
   const targets = readTargets();

--- a/scripts/check-image-drift.ts
+++ b/scripts/check-image-drift.ts
@@ -1,0 +1,314 @@
+#!/usr/bin/env -S node --experimental-strip-types --experimental-transform-types --no-warnings
+
+/**
+ * Answers one question per published image: was the `latest` tag in ghcr built
+ * from a commit whose sources still match this ref?
+ *
+ * Every build workflow fires on a `paths:` filter, and GitHub evaluates those
+ * filters against the two-dot diff between base and head. A merge whose diff is
+ * empty (a squash of an already-merged branch, for instance) matches no path, so
+ * every build is skipped and the merge ships nothing. Same for a source change
+ * that nobody thought to list under `paths:`. This finds those cases from the
+ * outside, by comparing what the registry says against what git says.
+ *
+ * No image is pulled and no build runs. The revision comes from the
+ * `org.opencontainers.image.revision` label that docker/metadata-action writes,
+ * read out of the image config blob over the registry API: anonymous token ->
+ * manifest -> config blob.
+ *
+ * The (image, paths) pairs are not maintained here. They are read out of
+ * .github/workflows/build-*.yml, so a new build workflow is covered the day it
+ * lands and a changed `paths:` filter changes this check with it.
+ *
+ *   npm run verify:images                     # against HEAD
+ *   npm run verify:images -- --ref b93c4ff    # against some other commit
+ *   npm run verify:images -- --wait 20        # give running builds 20 min to finish
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const WORKFLOW_DIR = join(ROOT, '.github/workflows');
+const REVISION_LABEL = 'org.opencontainers.image.revision';
+
+const MANIFEST_TYPES = [
+  'application/vnd.oci.image.index.v1+json',
+  'application/vnd.oci.image.manifest.v1+json',
+  'application/vnd.docker.distribution.manifest.list.v2+json',
+  'application/vnd.docker.distribution.manifest.v2+json',
+].join(', ');
+
+interface Target {
+  workflow: string;
+  image: string;
+  /** The workflow's `paths:` filter, translated to git pathspecs. */
+  pathspecs: string[];
+}
+
+type Result =
+  | { target: Target; state: 'ok'; revision: string }
+  | { target: Target; state: 'drift'; revision: string; files: string[] }
+  /* `pending` is a state a running build can still resolve; `error` never resolves
+   * on its own, so waiting on it would only waste the runner. */
+  | { target: Target; state: 'pending'; reason: string }
+  | { target: Target; state: 'error'; reason: string };
+
+interface WorkflowFile {
+  on?: {
+    push?: { paths?: string[] };
+  };
+  jobs?: Record<string, { steps?: { uses?: string; with?: Record<string, unknown> }[] }>;
+}
+
+/**
+ * GitHub's `paths:` globs and git's pathspecs are different languages. Only the
+ * trailing `/**` needs translating: a bare directory is already "everything below
+ * it" to git, and it keeps matching the gitlink of a submodule directory too.
+ */
+function toPathspec(pattern: string): string {
+  return pattern.replace(/\/\*\*$/, '');
+}
+
+function readTargets(): Target[] {
+  const targets: Target[] = [];
+
+  for (const file of readdirSync(WORKFLOW_DIR).sort()) {
+    if (!file.startsWith('build-') || !file.endsWith('.yml')) {
+      continue;
+    }
+
+    const workflow = yaml.load(readFileSync(join(WORKFLOW_DIR, file), 'utf8')) as WorkflowFile;
+    const paths = workflow.on?.push?.paths;
+    const images = Object.values(workflow.jobs ?? {})
+      .flatMap((job) => job.steps ?? [])
+      .filter((step) => step.uses?.startsWith('docker/metadata-action'))
+      .flatMap((step) => String(step.with?.images ?? '').split('\n'))
+      .map((image) => image.trim())
+      .filter(Boolean);
+
+    if (!paths?.length || images.length !== 1) {
+      throw new Error(
+        `${file}: expected one docker/metadata-action image and a push paths filter, ` +
+          `found ${images.length} image(s) and ${paths?.length ?? 0} path(s). ` +
+          'Either the workflow is shaped differently now or this check needs updating.',
+      );
+    }
+
+    targets.push({
+      workflow: file,
+      image: images[0],
+      pathspecs: [...new Set(paths.map(toPathspec))],
+    });
+  }
+
+  return targets;
+}
+
+class RegistryError extends Error {
+  constructor(
+    message: string,
+    /** True while a build could still make this succeed. */
+    readonly pending = false,
+  ) {
+    super(message);
+  }
+}
+
+async function fetchJson(url: string, token?: string, accept?: string): Promise<unknown> {
+  const response = await fetch(url, {
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(accept ? { Accept: accept } : {}),
+    },
+  });
+  if (!response.ok) {
+    throw new RegistryError(
+      `${response.status} ${response.statusText} for ${url}`,
+      response.status === 404,
+    );
+  }
+  return response.json();
+}
+
+/** Reads the revision label of a tag without pulling anything. */
+async function readRevision(image: string, tag = 'latest'): Promise<string> {
+  const [registry, ...rest] = image.split('/');
+  const repository = rest.join('/');
+  if (registry !== 'ghcr.io') {
+    throw new Error(`only ghcr.io is supported, got ${registry}`);
+  }
+
+  /* ghcr wants a bearer token even for public reads, and hands one out without
+   * credentials for images that are public. */
+  const auth = (await fetchJson(
+    `https://${registry}/token?service=${registry}&scope=repository:${repository}:pull`,
+  )) as { token: string };
+
+  const base = `https://${registry}/v2/${repository}`;
+  let manifest = (await fetchJson(`${base}/manifests/${tag}`, auth.token, MANIFEST_TYPES)) as {
+    manifests?: { digest: string; platform?: { os?: string; architecture?: string } }[];
+    config?: { digest: string };
+  };
+
+  if (manifest.manifests) {
+    /* Multi-platform index. Attestation entries carry platform unknown/unknown
+     * and no image config, so they have to be skipped. */
+    const entry =
+      manifest.manifests.find((m) => m.platform?.os === 'linux' && m.platform?.architecture === 'amd64') ??
+      manifest.manifests.find((m) => m.platform?.architecture !== 'unknown');
+    if (!entry) {
+      throw new Error(`no image manifest in the index for :${tag}`);
+    }
+    manifest = (await fetchJson(`${base}/manifests/${entry.digest}`, auth.token, MANIFEST_TYPES)) as {
+      config?: { digest: string };
+    };
+  }
+
+  if (!manifest.config?.digest) {
+    throw new Error(`manifest for :${tag} has no config descriptor`);
+  }
+
+  const config = (await fetchJson(`${base}/blobs/${manifest.config.digest}`, auth.token)) as {
+    config?: { Labels?: Record<string, string> };
+  };
+  const revision = config.config?.Labels?.[REVISION_LABEL];
+  if (!revision) {
+    throw new Error(
+      `:${tag} carries no ${REVISION_LABEL} label, so it cannot be traced to a commit`,
+    );
+  }
+  return revision;
+}
+
+function git(args: string[]): { status: number; stdout: string; stderr: string } {
+  const result = spawnSync('git', args, { cwd: ROOT, encoding: 'utf8' });
+  if (result.error) {
+    throw result.error;
+  }
+  return { status: result.status ?? 1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+}
+
+function driftingFiles(revision: string, ref: string, pathspecs: string[]): string[] {
+  const diff = git(['diff', '--name-only', revision, ref, '--', ...pathspecs]);
+  if (diff.status !== 0) {
+    throw new Error(`git diff failed: ${diff.stderr.trim()}`);
+  }
+  return diff.stdout.split('\n').filter(Boolean);
+}
+
+async function check(target: Target, ref: string): Promise<Result> {
+  let revision: string;
+  try {
+    revision = await readRevision(target.image);
+  } catch (error) {
+    const pending = error instanceof RegistryError && error.pending;
+    return { target, state: pending ? 'pending' : 'error', reason: (error as Error).message };
+  }
+
+  if (git(['cat-file', '-e', `${revision}^{commit}`]).status !== 0) {
+    return {
+      target,
+      state: 'error',
+      reason: `revision ${revision} is not in this clone - fetch the full history, or the image was built from a commit that no longer exists`,
+    };
+  }
+
+  const files = driftingFiles(revision, ref, target.pathspecs);
+  return files.length ? { target, state: 'drift', revision, files } : { target, state: 'ok', revision };
+}
+
+function report(results: Result[], ref: string, resolved: string): void {
+  console.log(`Comparing ghcr :latest against ${ref} (${resolved.slice(0, 7)})\n`);
+
+  for (const result of results.sort((a, b) => a.target.image.localeCompare(b.target.image))) {
+    const name = result.target.image.replace(/^ghcr\.io\//, '');
+    if (result.state === 'ok') {
+      console.log(`✓ ${name} @ ${result.revision.slice(0, 7)}`);
+      continue;
+    }
+    if (result.state === 'error' || result.state === 'pending') {
+      console.log(`? ${name}: ${result.reason}`);
+      continue;
+    }
+    console.log(
+      `✗ ${name} @ ${result.revision.slice(0, 7)}: ${result.files.length} file(s) differ since that build ` +
+        `(re-run ${result.target.workflow}):`,
+    );
+    for (const file of result.files.slice(0, 10)) {
+      console.log(`    ${file}`);
+    }
+    if (result.files.length > 10) {
+      console.log(`    ... and ${result.files.length - 10} more`);
+    }
+  }
+}
+
+function parseArgs(argv: string[]): { ref: string; waitMinutes: number } {
+  let ref = 'HEAD';
+  let waitMinutes = 0;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--ref') {
+      ref = argv[++i] ?? ref;
+    } else if (argv[i] === '--wait') {
+      waitMinutes = Number(argv[++i]);
+      if (!Number.isFinite(waitMinutes) || waitMinutes < 0) {
+        throw new Error('--wait takes a number of minutes');
+      }
+    } else {
+      throw new Error(`unknown argument: ${argv[i]}`);
+    }
+  }
+
+  return { ref, waitMinutes };
+}
+
+async function main(): Promise<void> {
+  const { ref, waitMinutes } = parseArgs(process.argv.slice(2));
+  const resolved = git(['rev-parse', ref]);
+  if (resolved.status !== 0) {
+    console.error(`Cannot resolve ${ref}: ${resolved.stderr.trim()}`);
+    process.exit(1);
+  }
+
+  const targets = readTargets();
+  let results = await Promise.all(targets.map((target) => check(target, ref)));
+
+  /* On a push to main the builds for that same commit are still running, and an
+   * image mid-rebuild looks exactly like a missed build. Re-poll rather than
+   * reporting the race as a defect. */
+  const unsettled = (result: Result) => result.state === 'drift' || result.state === 'pending';
+  const deadline = Date.now() + waitMinutes * 60_000;
+  while (results.some(unsettled) && Date.now() < deadline) {
+    const waiting = results.filter(unsettled);
+    console.log(`${waiting.length} image(s) not current yet, waiting for builds to finish...`);
+    await new Promise((resolve) => setTimeout(resolve, 60_000));
+    const rechecked = await Promise.all(waiting.map((r) => check(r.target, ref)));
+    results = [...results.filter((r) => !unsettled(r)), ...rechecked];
+  }
+
+  report(results, ref, resolved.stdout.trim());
+
+  const failed = results.filter((r) => r.state !== 'ok');
+  if (failed.length) {
+    console.error(
+      `\n${failed.length} of ${results.length} images do not match ${ref}. ` +
+        'Re-run the build workflow for each (Actions -> the workflow -> Run workflow) ' +
+        'and check whether its paths filter should have caught the change.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`\nAll ${results.length} images were built from ${ref}.`);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error((error as Error).message);
+  process.exit(1);
+}


### PR DESCRIPTION
Zwei CI-Wächter für die beiden Fehlerarten, die zuletzt Produktion getroffen haben: eine Config, die das Image nie hätte erreichen dürfen, und ein Merge, der überhaupt kein Image gebaut hat.

Refs #96

## 1. `librechat.yaml` wird vor dem Image validiert

`npm run validate:config` existierte schon, lief aber in keinem Workflow. Genau der Verstoß, der die API in Produktion in eine Crashloop geschickt hat (`title: E-Mail` - `mcpServers.*.title` muss `/^[a-zA-Z0-9 ]+$/` erfüllen), konnte also unbemerkt ins Image wandern.

`build-librechat-init.yml` validiert jetzt vor dem Build. Das Schema kommt aus dem Fork selbst (`data-provider`), also prüft der Job gegen das, was das deployte Image akzeptiert. Es wird nur `dev/librechat` auf dem gepinnten Commit ausgecheckt und nur dieses eine Workspace-Paket installiert - `submodules: true` würde alle 15 Submodule für einen Config-Lint klonen. Kosten: rund 21 Sekunden im Job (6s Install, 14s Schema-Build, 1s Validierung).

`js-yaml` ist jetzt eine echte Root-devDependency. Es lag bisher nur durch Hoisting aus `mcp-linux` im Baum, das Validator-Skript importiert es aber direkt.

## 2. `verify-images.yml` prüft, ob jedes `:latest` wirklich aus main gebaut wurde

Der eigentliche Defekt beim letzten Vorfall war nicht die Config, sondern das Abzweigen von einem bereits gemergten Branch: f911df0 war ein leerer Squash, byte-identisch zum Parent. GitHub wertet `paths:`-Filter bei Push gegen das Zwei-Punkt-Diff zwischen Base und Head aus, ein leeres Diff trifft keinen Pfad, also wurden alle 14 Build-Workflows übersprungen. Der Merge war grün und hat nichts ausgeliefert.

Der neue Workflow baut kein einziges Image. Er liest pro Image das Label `org.opencontainers.image.revision` des `latest`-Tags direkt über die Registry-API aus (Token, Manifest, Config-Blob - drei Requests, kein Pull) und vergleicht per `git diff` gegen die Pfade, auf die der jeweilige Build-Workflow hört. Alle abweichenden Images werden in einem Lauf gemeldet, nicht nur das erste. Trigger: Push auf main ohne `paths:`-Filter (ein Filter würde genau den Fall ausblenden, den der Check finden soll) plus täglich per Cron.

Die (Image, Pfade)-Paare stehen nicht im Skript, sondern werden aus `.github/workflows/build-*.yml` gelesen. Ein neuer Build-Workflow ist damit ab dem Tag abgedeckt, an dem er landet, und ein geänderter `paths:`-Filter ändert den Check mit.

Bei einem Push auf main laufen die Builds für denselben Commit noch, ein Image mitten im Rebuild sieht genauso aus wie ein verpasster Build. Deshalb `--wait 20`: der Check pollt die Registry für die noch nicht passenden Images, statt das Rennen als Defekt zu melden. Der Cron-Lauf wartet nicht.

Lokal nutzbar: `npm run verify:images`, optional `--ref <commit>`.

### Warum nicht einfach bei jedem Merge alles neu bauen

Das hätte die Lücke auch geschlossen und wurde aus Kostengründen verworfen - nicht nur Runner-Minuten, sondern Risiko:

- Unter `packages/` liegt kein einziges Lockfile, `npm install` im Dockerfile löst also bei jedem Build frisch auf.
- Alle Base-Images floaten (`node:24`, `node:24-alpine`, `ubuntu:24.04`, `python:3.12-slim`).

Ein grundloser Rebuild ist damit eine frische Gelegenheit, fremden Dependency-Drift auszuliefern. Bei der Untersuchung zum Vorfall wurde beobachtet, dass zwei Builds eines byte-identischen Trees 5 unterschiedliche Layer erzeugen. Ein Check, der nichts baut, hat dieses Risiko nicht.

## 3. `.gitmodules` in den `paths:`-Filter der Submodul-Builds

Eine Änderung an einer `url =` in `.gitmodules` verbiegt, was `actions/checkout` auflöst - das Image würde also aus einem anderen Quellbaum gebaut. Bisher hörte kein Workflow auf die Datei, es wurde nichts neu gebaut. Ergänzt in den sechs Workflows, die aus einem Submodul bauen: librechat, mcp-db-timetable, mcp-docs, mcp-npm-search, mcp-openstreetmap, mcp-stackoverflow. Die übrigen acht bauen aus `packages/` und berühren kein Submodul.

## Verifiziert

- Der neue Job ist auf diesem Branch echt gelaufen: alle Schritte grün, `✓ local ✓ dev ✓ prod`, Gesamtjob 1m8s.
- Gate greift: mit `title: E-Mail` an Zeile 948 meldet die Validierung `mcpServers.mail.title: Title can only contain letters, numbers, and spaces` für alle drei Umgebungen und beendet sich mit 1.
- Das Revision-Label ist auf echten Images vorhanden, es musste nichts ergänzt werden. `ghcr.io/faktenforum/librechat-init:latest` trägt `org.opencontainers.image.revision = dba82bb88c334fecbecf60b5564bd80a1352035d`, also den aktuellen main-Stand. Alle 14 Images liefern das Label anonym lesbar aus.
- Drift-Logik gegen einen bekannten Fall: mit `--ref b93c4ff` gegen das real gelesene `dba82bb` meldet der Check `librechat-init` als abweichend (`packages/librechat-init/config/librechat.yaml`) und beendet sich mit 1.

### Erwartung beim Merge

Der Merge ändert sieben Build-Workflow-Dateien, die jeweils in ihrem eigenen `paths:`-Filter stehen. Diese sieben Images werden also neu gebaut. Der erste `verify-images`-Lauf auf main meldet sie so lange als abweichend, bis die Builds durch sind - dafür ist das `--wait` da. Zusätzlich ist `.gitmodules` seit dem letzten Build der fünf Submodul-Images geändert worden (unabhängige Submodule kamen hinzu), was der Rebuild im selben Zug erledigt.
